### PR TITLE
use non-fixed number for local udp port

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -27,7 +27,7 @@ impl From<io::Error> for SearchError {
 // Try to find the gateway on the local network.
 // Bind to the given interface.
 pub fn search_gateway_from(ip: Ipv4Addr) -> Result<SocketAddrV4, SearchError> {
-    let addr = SocketAddrV4::new(ip, 1900);
+    let addr = SocketAddrV4::new(ip, 0);
     let socket = try!(UdpSocket::bind(addr));
 
     // send the request on the broadcast address


### PR DESCRIPTION
It helps to avoid "Address already in use (os error 98)" when multiple
instances are started.

This is safe, because responses to such search requests are sent via
unicast addressing to the originating address and port number of the
multicast request.