### PR TITLE
Fixes xml-rs dependency to version 0.1.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 
 [dependencies]
 regex = "*"
-xml-rs = "*"
+xml-rs = "0.1.25"
 
 [dependencies.hyper]
 version = "0.6.*"


### PR DESCRIPTION
The new version has different API and breaks this lib.