### PR TITLE
Add udp socket read timeout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,9 @@ xml-rs = "0.1.25"
 [dependencies.hyper]
 version = "0.6.*"
 default-features = false
+
+[features]
+# Use unstable features of libstd. This enables the search_gateway_timeout and
+# search_gateway_from_timeout functions.
+unstable = []
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,11 @@ pub use self::search::search_gateway;
 pub use self::search::search_gateway_from;
 pub use self::search::SearchError;
 
+#[cfg(feature = "unstable")]
+pub use self::search::search_gateway_timeout;
+#[cfg(feature = "unstable")]
+pub use self::search::search_gateway_from_timeout;
+
 // re-export error types
 pub use hyper::Error as HttpError;
 pub use xml::common::Error as XmlError;

--- a/src/search.rs
+++ b/src/search.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::net::{Ipv4Addr, SocketAddrV4};
 use std::net::UdpSocket;
 use std::str;
+use std::time::Duration;
 
 use hyper;
 use regex::Regex;
@@ -58,6 +59,9 @@ impl From<XmlError> for SearchError {
 pub fn search_gateway_from(ip: Ipv4Addr) -> Result<Gateway, SearchError> {
     let addr = SocketAddrV4::new(ip, 0);
     let socket = try!(UdpSocket::bind(addr));
+
+    // wait one second for a response
+    try!(socket.set_read_timeout(Some(Duration::from_secs(1))));
 
     // send the request on the broadcast address
     try!(socket.send_to(SEARCH_REQUEST.as_bytes(), "239.255.255.250:1900"));


### PR DESCRIPTION
`search_gateway_from` can block forever without any way to kill it. This sets a one second timeout waiting for a response from the gateway. An alternative would be to add something like

    search_gateway_from_timeout(ip: Ipv4Addr, timeout: Duration)

Although realistically if the gateway doesn't respond after one second it's unlikely to ever respond.