### PR TITLE
More detailed errors, Gateway::add_any_port method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ license = "MIT"
 regex = "0.1.41"
 xml-rs = "0.1.25"
 xmltree = "0.3"
+rand = "0.3"
 
 [dependencies.hyper]
 version = "0.6.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ license = "MIT"
 [dependencies]
 regex = "0.1.41"
 xml-rs = "0.1.25"
+xmltree = "*"
 
 [dependencies.hyper]
 version = "0.6.*"
 default-features = false
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 [dependencies]
 regex = "0.1.41"
 xml-rs = "0.1.25"
-xmltree = "*"
+xmltree = "0.3"
 
 [dependencies.hyper]
 version = "0.6.*"

--- a/examples/add_any_port.rs
+++ b/examples/add_any_port.rs
@@ -14,7 +14,7 @@ fn main() {
             let local_addr = SocketAddrV4::new(local_addr, 8080u16);
 
             match gateway.add_any_port(igd::PortMappingProtocol::TCP,
-                                       local_addr, 0, "add_port example") {
+                                       local_addr, 60, "add_port example") {
                 Err(ref err) => {
                     println!("There was an error! {}", err);
                 },

--- a/examples/add_any_port.rs
+++ b/examples/add_any_port.rs
@@ -4,10 +4,7 @@ extern crate igd;
 
 fn main() {
     match igd::search_gateway() {
-        Err(ref err) => match *err {
-            igd::SearchError::IoError(ref ioe) => println!("IoError: {}", ioe),
-            _ => println!("Error: {}", err),
-        },
+        Err(ref err) => println!("Error: {}", err),
         Ok(gateway) => {
             let local_addr = match std::env::args().nth(1) {
                 Some(local_addr) => local_addr,

--- a/examples/add_any_port.rs
+++ b/examples/add_any_port.rs
@@ -1,0 +1,30 @@
+use std::net::{SocketAddrV4, Ipv4Addr};
+
+extern crate igd;
+
+fn main() {
+    match igd::search_gateway() {
+        Err(ref err) => match *err {
+            igd::SearchError::IoError(ref ioe) => println!("IoError: {}", ioe),
+            _ => println!("Error: {}", err),
+        },
+        Ok(gateway) => {
+            let local_addr = match std::env::args().nth(1) {
+                Some(local_addr) => local_addr,
+                None => panic!("Expected IP address (cargo run --example add_any_port <your IP here>)"),
+            };
+            let local_addr = local_addr.parse::<Ipv4Addr>().unwrap();
+            let local_addr = SocketAddrV4::new(local_addr, 8080u16);
+
+            match gateway.add_any_port(igd::PortMappingProtocol::TCP,
+                                       local_addr, 0, "add_port example") {
+                Err(ref err) => {
+                    println!("There was an error! {}", err);
+                },
+                Ok(port) => {
+                    println!("It worked! Got port {}", port);
+                },
+            }
+        },
+    }
+}

--- a/examples/add_port.rs
+++ b/examples/add_port.rs
@@ -4,16 +4,17 @@ extern crate igd;
 
 fn main() {
     match igd::search_gateway() {
-        Err(ref err) => match *err {
-            igd::SearchError::IoError(ref ioe) => println!("IoError: {}", ioe),
-            _ => println!("{:?}", err),
-        },
+        Err(ref err) => println!("Error: {}", err),
         Ok(gateway) => {
-            let local_addr = "192.168.1.2".parse::<Ipv4Addr>().unwrap();
+            let local_addr = match std::env::args().nth(1) {
+                Some(local_addr) => local_addr,
+                None => panic!("Expected IP address (cargo run --example add_port <your IP here>)"),
+            };
+            let local_addr = local_addr.parse::<Ipv4Addr>().unwrap();
             let local_addr = SocketAddrV4::new(local_addr, 8080u16);
 
             match gateway.add_port(igd::PortMappingProtocol::TCP, 80,
-                                   local_addr, 0, "crust") {
+                                   local_addr, 0, "add_port example") {
                 Err(ref err) => {
                     println!("There was an error! {}", err);
                 },

--- a/examples/add_port.rs
+++ b/examples/add_port.rs
@@ -14,7 +14,7 @@ fn main() {
             let local_addr = SocketAddrV4::new(local_addr, 8080u16);
 
             match gateway.add_port(igd::PortMappingProtocol::TCP, 80,
-                                   local_addr, 0, "add_port example") {
+                                   local_addr, 60, "add_port example") {
                 Err(ref err) => {
                     println!("There was an error! {}", err);
                 },

--- a/examples/add_port.rs
+++ b/examples/add_port.rs
@@ -13,12 +13,9 @@ fn main() {
             let local_addr = SocketAddrV4::new(local_addr, 8080u16);
 
             match gateway.add_port(igd::PortMappingProtocol::TCP, 80,
-                                local_addr, 0, "crust") {
-                Err(ref err) => match *err {
-                    igd::RequestError::IoError(ref ioe) => {
-                        println!("IoError: {}", ioe)
-                    },
-                    _ => println!("{:?}", err),
+                                   local_addr, 0, "crust") {
+                Err(ref err) => {
+                    println!("There was an error! {}", err);
                 },
                 Ok(()) => {
                     println!("It worked");

--- a/examples/external_ip.rs
+++ b/examples/external_ip.rs
@@ -5,7 +5,9 @@ fn main() {
         Err(ref err) => println!("{:?}", err),
         Ok(gateway) => {
             match gateway.get_external_ip() {
-                Err(ref err) => println!("{:?}", err),
+                Err(ref err) => {
+                    println!("There was an error! {}", err);
+                },
                 Ok(ext_addr) => {
                     println!("Local gateway: {}, External ip address: {}", gateway, ext_addr);
                 },

--- a/examples/external_ip.rs
+++ b/examples/external_ip.rs
@@ -2,7 +2,7 @@ extern crate igd;
 
 fn main() {
     match igd::search_gateway() {
-        Err(ref err) => println!("{:?}", err),
+        Err(ref err) => println!("Error: {}", err),
         Ok(gateway) => {
             match gateway.get_external_ip() {
                 Err(ref err) => {

--- a/examples/remove_port.rs
+++ b/examples/remove_port.rs
@@ -7,13 +7,9 @@ fn main() {
             _ => println!("{:?}", err),
         },
         Ok(gateway) => {
-            match gateway.remove_port(igd::PortMappingProtocol::TCP,
-                                   80) {
-                Err(ref err) => match *err {
-                    igd::RequestError::IoError(ref ioe) => {
-                        println!("IoError: {}", ioe)
-                    },
-                    _ => println!("{:?}", err),
+            match gateway.remove_port(igd::PortMappingProtocol::TCP, 80) {
+                Err(ref err) => {
+                    println!("There was an error! {}", err);
                 },
                 Ok(()) => {
                     println!("It worked");

--- a/examples/remove_port.rs
+++ b/examples/remove_port.rs
@@ -2,10 +2,7 @@ extern crate igd;
 
 fn main() {
     match igd::search_gateway() {
-        Err(ref err) => match *err {
-            igd::SearchError::IoError(ref ioe) => println!("IoError: {}", ioe),
-            _ => println!("{:?}", err),
-        },
+        Err(ref err) => println!("Error: {}", err),
         Ok(gateway) => {
             match gateway.remove_port(igd::PortMappingProtocol::TCP, 80) {
                 Err(ref err) => {

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -11,39 +11,44 @@ use soap;
 
 /// Errors that can occur when sending the request to the gateway.
 #[derive(Debug)]
-pub enum RequestError<E: fmt::Debug> {
+pub enum RequestError {
     /// Http/Hyper error
     HttpError(hyper::Error),
-    /// Unable to process the response
-    InvalidResponse,
     /// IO Error
     IoError(io::Error),
-    /// The gateway responded with an error.
-    ErrorResponse(E),
+    /// The response from the gateway could not be parsed.
+    InvalidResponse(String),
+    /// The gateway returned an unhandled error code and description.
+    ErrorCode(u16, String),
 }
 
+/// Errors returned by `Gateway::get_external_ip`
 #[derive(Debug)]
 pub enum GetExternalIpError {
     /// The client is not authorized to perform the operation.
     ActionNotAuthorized,
-    /// The gateway returned an unrecognized error string.
-    ErrorString(String),
+    /// Some other error occured performing the request.
+    RequestError(RequestError),
 }
 
+/// Errors returned by `Gateway::remove_port`
 #[derive(Debug)]
 pub enum RemovePortError {
     /// The client is not authorized to perform the operation.
     ActionNotAuthorized,
     /// No such port mapping.
     NoSuchPortMapping,
-    /// The gateway returned an unrecognized error string.
-    ErrorString(String),
+    /// Some other error occured performing the request.
+    RequestError(RequestError),
 }
 
+/// Errors returned by `Gateway::add_any_port`
 #[derive(Debug)]
 pub enum AddAnyPortError {
     /// The client is not authorized to perform the operation.
     ActionNotAuthorized,
+    /// Can not add a mapping for local port 0.
+    InternalPortZeroInvalid,
     /// The gateway does not have any free ports.
     NoPortsAvailable,
     /// The gateway can only map internal ports to same-numbered external ports
@@ -51,35 +56,41 @@ pub enum AddAnyPortError {
     ExternalPortInUse,
     /// The gateway only supports permanent leases (ie. a `lease_duration` of 0).
     OnlyPermanentLeasesSupported,
-    /// The gateway returned an unrecognized error string.
-    ErrorString(String),
+    /// The description was too long for the gateway to handle.
+    DescriptionTooLong,
+    /// Some other error occured performing the request.
+    RequestError(RequestError),
 }
 
-/// Errors returned by the gateway when trying to add a port.
+/// Errors returned by `Gateway::add_port`
 #[derive(Debug)]
 pub enum AddPortError {
     /// The client is not authorized to perform the operation.
     ActionNotAuthorized,
+    /// Can not add a mapping for local port 0.
+    InternalPortZeroInvalid,
     /// External port number 0 (any port) is considered invalid by the gateway.
-    WildCardNotPermittedInExtPort,
+    ExternalPortZeroInvalid,
     /// The requested mapping conflicts with a mapping assigned to another client.
-    ConflictInMappingEntry,
+    PortInUse,
     /// The gateway requires that the requested internal and external ports are the same.
     SamePortValuesRequired,
     /// The gateway only supports permanent leases (ie. a `lease_duration` of 0).
     OnlyPermanentLeasesSupported,
-    /// The gateway returned an unrecognized error string.
-    ErrorString(String),
+    /// The description was too long for the gateway to handle.
+    DescriptionTooLong,
+    /// Some other error occured performing the request.
+    RequestError(RequestError),
 }
 
-impl<E: fmt::Debug> From<io::Error> for RequestError<E> {
-    fn from(err: io::Error) -> RequestError<E> {
+impl From<io::Error> for RequestError {
+    fn from(err: io::Error) -> RequestError {
         RequestError::IoError(err)
     }
 }
 
-impl<E: fmt::Debug> From<soap::Error> for RequestError<E> {
-    fn from(err: soap::Error) -> RequestError<E> {
+impl From<soap::Error> for RequestError {
+    fn from(err: soap::Error) -> RequestError {
         match err {
             soap::Error::HttpError(e) => RequestError::HttpError(e),
             soap::Error::IoError(e) => RequestError::IoError(e),
@@ -87,33 +98,33 @@ impl<E: fmt::Debug> From<soap::Error> for RequestError<E> {
     }
 }
 
-impl<E: fmt::Debug + fmt::Display> fmt::Display for RequestError<E> {
+impl fmt::Display for RequestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            RequestError::HttpError(ref e) => write!(f, "Http error. {}", e),
-            RequestError::InvalidResponse => write!(f, "Invalid response from gateway."),
+            RequestError::HttpError(ref e) => write!(f, "HTTP error. {}", e),
+            RequestError::InvalidResponse(ref e) => write!(f, "Invalid response from gateway: {}", e),
             RequestError::IoError(ref e) => write!(f, "IO error. {}", e),
-            RequestError::ErrorResponse(ref e) => write!(f, "The gateway responded with an error. {}", e),
+            RequestError::ErrorCode(n, ref e) => write!(f, "Gateway response error {}: {}", n, e),
         }
     }
 }
 
-impl<E: std::error::Error> std::error::Error for RequestError<E> {
+impl std::error::Error for RequestError {
     fn cause(&self) -> Option<&std::error::Error> {
         match *self {
             RequestError::HttpError(ref e)     => Some(e),
-            RequestError::InvalidResponse      => None,
+            RequestError::InvalidResponse(..)  => None,
             RequestError::IoError(ref e)       => Some(e),
-            RequestError::ErrorResponse(ref e) => Some(e),
+            RequestError::ErrorCode(..)        => None,
         }
     }
 
     fn description(&self) -> &str {
         match *self {
-            RequestError::HttpError(..)     => "Http error",
-            RequestError::InvalidResponse   => "Invalid response",
-            RequestError::IoError(..)       => "IO error",
-            RequestError::ErrorResponse(..) => "Error response",
+            RequestError::HttpError(..)       => "Http error",
+            RequestError::InvalidResponse(..) => "Invalid response",
+            RequestError::IoError(..)         => "IO error",
+            RequestError::ErrorCode(_, ref e) => &e[..],
         }
     }
 }
@@ -123,8 +134,8 @@ impl fmt::Display for GetExternalIpError {
         match *self {
             GetExternalIpError::ActionNotAuthorized
                 => write!(f, "The client is not authorized to remove the port"),
-            GetExternalIpError::ErrorString(ref s)
-                => write!(f, "The gateway returned an unrecognized error string: \"{}\"", s),
+            GetExternalIpError::RequestError(ref e)
+                => write!(f, "Request Error. {}", e),
         }
     }
 }
@@ -138,8 +149,8 @@ impl std::error::Error for GetExternalIpError {
         match *self {
             GetExternalIpError::ActionNotAuthorized
                 => "The client is not authorized to remove the port",
-            GetExternalIpError::ErrorString(ref s)
-                => &s[..],
+            GetExternalIpError::RequestError(..)
+                => "Request error",
         }
     }
 }
@@ -151,8 +162,8 @@ impl fmt::Display for RemovePortError {
                 => write!(f, "The client is not authorized to remove the port"),
             RemovePortError::NoSuchPortMapping
                 => write!(f, "The port was not mapped"),
-            RemovePortError::ErrorString(ref s)
-                => write!(f, "The gateway returned an unrecognized error string: \"{}\"", s),
+            RemovePortError::RequestError(ref e)
+                => write!(f, "Request error. {}", e),
         }
     }
 }
@@ -168,8 +179,8 @@ impl std::error::Error for RemovePortError {
                 => "The client is not authorized to remove the port",
             RemovePortError::NoSuchPortMapping
                 => "The port was not mapped",
-            RemovePortError::ErrorString(ref s)
-                => &s[..],
+            RemovePortError::RequestError(..)
+                => "Request error",
         }
     }
 }
@@ -179,14 +190,18 @@ impl fmt::Display for AddAnyPortError {
         match *self {
             AddAnyPortError::ActionNotAuthorized
                 => write!(f, "The client is not authorized to remove the port"),
+            AddAnyPortError::InternalPortZeroInvalid
+                => write!(f, "Can not add a mapping for local port 0"),
             AddAnyPortError::NoPortsAvailable
                 => write!(f, "The gateway does not have any free ports"),
             AddAnyPortError::OnlyPermanentLeasesSupported
                 => write!(f, "The gateway only supports permanent leases (ie. a `lease_duration` of 0),"),
             AddAnyPortError::ExternalPortInUse
                 => write!(f, "The gateway can only map internal ports to same-numbered external ports and this external port is in use."),
-            AddAnyPortError::ErrorString(ref s)
-                => write!(f, "The gateway returned an unrecognized error string: \"{}\"", s),
+            AddAnyPortError::DescriptionTooLong
+                => write!(f, "The description was too long for the gateway to handle."),
+            AddAnyPortError::RequestError(ref e)
+                => write!(f, "Request error. {}", e),
         }
     }
 }
@@ -200,14 +215,18 @@ impl std::error::Error for AddAnyPortError {
         match *self {
             AddAnyPortError::ActionNotAuthorized
                 => "The client is not authorized to remove the port",
+            AddAnyPortError::InternalPortZeroInvalid
+                => "Can not add a mapping for local port 0.",
             AddAnyPortError::NoPortsAvailable
                 => "The gateway does not have any free ports",
             AddAnyPortError::OnlyPermanentLeasesSupported
                 => "The gateway only supports permanent leases (ie. a `lease_duration` of 0),",
             AddAnyPortError::ExternalPortInUse
                 => "The gateway can only map internal ports to same-numbered external ports and this external port is in use.",
-            AddAnyPortError::ErrorString(ref s)
-                => &s[..],
+            AddAnyPortError::DescriptionTooLong
+                => "The description was too long for the gateway to handle.",
+            AddAnyPortError::RequestError(..)
+                => "Request error",
         }
     }
 }
@@ -217,16 +236,20 @@ impl fmt::Display for AddPortError {
         match *self {
             AddPortError::ActionNotAuthorized
                 => write!(f, "The client is not authorized to map this port."),
-            AddPortError::WildCardNotPermittedInExtPort
+            AddPortError::InternalPortZeroInvalid
+                => write!(f, "Can not add a mapping for local port 0"),
+            AddPortError::ExternalPortZeroInvalid
                 => write!(f, "External port number 0 (any port) is considered invalid by the gateway."),
-            AddPortError::ConflictInMappingEntry
+            AddPortError::PortInUse
                 => write!(f, "The requested mapping conflicts with a mapping assigned to another client."),
             AddPortError::SamePortValuesRequired
                 => write!(f, "The gateway requires that the requested internal and external ports are the same."),
             AddPortError::OnlyPermanentLeasesSupported
                 => write!(f, "The gateway only supports permanent leases (ie. a `lease_duration` of 0),"),
-            AddPortError::ErrorString(ref s)
-                => write!(f, "The gateway returned an unrecognized error string: \"{}\"", s),
+            AddPortError::DescriptionTooLong
+                => write!(f, "The description was too long for the gateway to handle."),
+            AddPortError::RequestError(ref e)
+                => write!(f, "Request error. {}", e),
         }
     }
 }
@@ -240,16 +263,20 @@ impl std::error::Error for AddPortError {
         match *self {
             AddPortError::ActionNotAuthorized
                 => "The client is not authorized to map this port.",
-            AddPortError::WildCardNotPermittedInExtPort
+            AddPortError::InternalPortZeroInvalid
+                => "Can not add a mapping for local port 0",
+            AddPortError::ExternalPortZeroInvalid
                 => "External port number 0 (any port) is considered invalid by the gateway.",
-            AddPortError::ConflictInMappingEntry
+            AddPortError::PortInUse
                 => "The requested mapping conflicts with a mapping assigned to another client.",
             AddPortError::SamePortValuesRequired
                 => "The gateway requires that the requested internal and external ports are the same.",
             AddPortError::OnlyPermanentLeasesSupported
                 => "The gateway only supports permanent leases (ie. a `lease_duration` of 0),",
-            AddPortError::ErrorString(ref s)
-                => &s[..],
+            AddPortError::DescriptionTooLong
+                => "The description was too long for the gateway to handle.",
+            AddPortError::RequestError(..)
+                => "Request error",
         }
     }
 }
@@ -282,11 +309,46 @@ pub struct Gateway {
 }
 
 impl Gateway {
+    fn perform_request(&self, header: &str, body: &str, ok: &str) -> Result<(String, xmltree::Element), RequestError> {
+        let url = format!("{}", self);
+        let text = try!(soap::send(&url, soap::Action::new(header), body));
+        let mut xml = match xmltree::Element::parse(text.as_bytes()) {
+            Ok(xml) => xml,
+            Err(..) => return Err(RequestError::InvalidResponse(text)),
+        };
+        let mut body = match xml.get_mut_child("Body")
+        {
+            Some(body) => body,
+            None => return Err(RequestError::InvalidResponse(text)),
+        };
+        if let Some(ok) = body.take_child(ok) {
+            return Ok((text, ok))
+        }
+        let upnp_error = match body.get_child("Fault")
+                              .and_then(|e| e.get_child("UPnPError"))
+                              .and_then(|e| e.get_child("detail"))
+        {
+            Some(upnp_error) => upnp_error,
+            None => return Err(RequestError::InvalidResponse(text)),
+        };
+        match (upnp_error.get_child("errorCode"), upnp_error.get_child("errorDescription")) {
+            (Some(e), Some(d)) => match (e.text.as_ref(), d.text.as_ref()) {
+                (Some(et), Some(dt)) => {
+                    match et.parse::<u16>() {
+                        Ok(en)  => Err(RequestError::ErrorCode(en, From::from(&dt[..]))),
+                        Err(..) => Err(RequestError::InvalidResponse(text)),
+                    }
+                },
+                _ => Err(RequestError::InvalidResponse(text)),
+            },
+            _ => Err(RequestError::InvalidResponse(text)),
+        }
+    }
 
     /// Get the external IP address of the gateway.
-    pub fn get_external_ip(&self) -> Result<Ipv4Addr, RequestError<GetExternalIpError>> {
-        use RequestError::*;
-        let url = format!("{}", self);
+    pub fn get_external_ip(&self) -> Result<Ipv4Addr, GetExternalIpError> {
+        // Content of the get external ip SOAPAction request header.
+        let header = "\"urn:schemas-upnp-org:service:WANIPConnection:1#GetExternalIPAddress\"";
         let body = "<?xml version=\"1.0\"?>
         <SOAP-ENV:Envelope SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\">
             <SOAP-ENV:Body>
@@ -294,44 +356,19 @@ impl Gateway {
                 </m:GetExternalIPAddress>
             </SOAP-ENV:Body>
         </SOAP-ENV:Envelope>";
-
-        let text = try!(soap::send(&url, soap::Action::new(GET_EXTERNAL_IP_ACTION), body));
-
-        let xml = match xmltree::Element::parse(text.as_bytes()) {
-            Ok(xml) => xml,
-            Err(..) => return Err(InvalidResponse),
-        };
-
-        let body = match xml.get_child("Body")
-        {
-            Some(body) => body,
-            None => return Err(InvalidResponse),
-        };
-        if let Some(ext_ip) = body.get_child("GetExternalIPAddressResponse")
-                                  .and_then(|e| e.get_child("NewExternalIPAddress"))
-        {
-            match ext_ip.text {
-                Some(ref t) => match t.parse::<Ipv4Addr>() {
-                    Ok(ipv4_addr) => return Ok(ipv4_addr),
-                    Err(..) => return Err(InvalidResponse),
-                },
-                None => return Err(InvalidResponse),
-            }
-        };
-        if let Some(fault) = body.get_child("Fault") {
-            match fault.get_child("detail")
-                       .and_then(|e| e.get_child("UPnPError"))
-                       .and_then(|e| e.get_child("errorDescription"))
-                       .and_then(|e| e.text.as_ref())
-            {
-                Some(description) => match &description[..] {
-                    "Action not authorized" => return Err(ErrorResponse(GetExternalIpError::ActionNotAuthorized)),
-                    d => return Err(ErrorResponse(GetExternalIpError::ErrorString(From::from(d)))),
-                },
-                None => return Err(InvalidResponse),
-            };
+        match self.perform_request(header, body, "GetExternalIPAddressResponse") {
+            Ok((text, response)) => {
+                match response.get_child("NewExternalIPAddress")
+                              .and_then(|e| e.text.as_ref())
+                              .and_then(|t| t.parse::<Ipv4Addr>().ok())
+                {
+                    Some(ipv4_addr) => Ok(ipv4_addr),
+                    None => Err(GetExternalIpError::RequestError(RequestError::InvalidResponse(text))),
+                }
+            },
+            Err(RequestError::ErrorCode(606, _)) => Err(GetExternalIpError::ActionNotAuthorized),
+            Err(e) => Err(GetExternalIpError::RequestError(e)),
         }
-        Err(InvalidResponse)
     }
 
     /// Add a port mapping.with any external port.
@@ -345,21 +382,23 @@ impl Gateway {
     pub fn add_any_port(&self, protocol: PortMappingProtocol,
                         local_addr: SocketAddrV4,
                         lease_duration: u32, description: &str)
-            -> Result<u16, RequestError<AddAnyPortError>>
+            -> Result<u16, AddAnyPortError>
     {
         // This function first attempts to call AddAnyPortMapping on the IGD with a random port
         // number. If that fails due to the method being unknown it attempts to call AddPortMapping
-        // instead with a random port number. If that fails due to ActionNotAuthorized or
-        // ConflictInMappingEntry it retrys with another port up to a maximum of 20 times. If it
-        // fails due to SamePortValuesRequired it retrys once with the same port values.
+        // instead with a random port number. If that fails due to ConflictInMappingEntry it retrys
+        // with another port up to a maximum of 20 times. If it fails due to SamePortValuesRequired
+        // it retrys once with the same port values.
 
-        use RequestError::*;
+        if local_addr.port() == 0 {
+            return Err(AddAnyPortError::InternalPortZeroInvalid)
+        }
 
         let port_range = rand::distributions::Range::new(32768u16, 65535u16);
         let mut rng = rand::thread_rng();
         let external_port = port_range.ind_sample(&mut rng);
 
-        let url = format!("{}", self);
+        let header = "\"urn:schemas-upnp-org:service:WANIPConnection:1#AddAnyPortMapping\"";
         let body = format!("<?xml version=\"1.0\"?>
         <s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">
         <s:Body>
@@ -377,102 +416,57 @@ impl Gateway {
         </s:Envelope>
         ", protocol, external_port, local_addr.ip(),
            local_addr.port(), lease_duration, description);
-
-        let text = try!(soap::send(&url, soap::Action::new(ADD_ANY_PORT_ACTION), &body));
-        println!("got text: {}", text);
-
-        let xml = match xmltree::Element::parse(text.as_bytes()) {
-            Ok(xml) => xml,
-            Err(..) => return Err(InvalidResponse),
-        };
-
-        let body = match xml.get_child("Body")
-        {
-            Some(body) => body,
-            None => return Err(InvalidResponse),
-        };
-        if let Some(ext_ip) = body.get_child("AddAnyPortMappingResponse")
-                                  .and_then(|e| e.get_child("NewReservedPort"))
-        {
-            match ext_ip.text {
-                Some(ref t) => match t.parse::<u16>() {
-                    Ok(port) => return Ok(port),
-                    Err(..) => return Err(InvalidResponse),
-                },
-                None => return Err(InvalidResponse),
+        // First, attempt to call the AddAnyPortMapping method.
+        match self.perform_request(header, &*body, "AddAnyPortMappingResponse") {
+            Ok((text, response)) => {
+                match response.get_child("NewReservedPort")
+                              .and_then(|e| e.text.as_ref())
+                              .and_then(|t| t.parse::<u16>().ok())
+                {
+                    Some(port) => Ok(port),
+                    None => Err(AddAnyPortError::RequestError(RequestError::InvalidResponse(text))),
+                }
             }
-        };
-        if let Some(fault) = body.get_child("Fault") {
-            match fault.get_child("detail")
-                       .and_then(|e| e.get_child("UPnPError"))
-                       .and_then(|e| e.get_child("errorDescription"))
-                       .and_then(|e| e.text.as_ref())
-            {
-                Some(description) => match &description[..] {
-                    "InvalidAction" => {
-                        for _attempt in 0..20 {
-                            let external_port = port_range.ind_sample(&mut rng);
-                            match self.add_port(protocol, external_port, local_addr,
-                                                lease_duration, description)
-                            {
-                                Ok(()) => return Ok(external_port),
-                                Err(ErrorResponse(AddPortError::ActionNotAuthorized)) |
-                                Err(ErrorResponse(AddPortError::ConflictInMappingEntry))
-                                    => continue,
-                                Err(ErrorResponse(AddPortError::SamePortValuesRequired)) => {
-                                    match self.add_port(protocol, local_addr.port(), local_addr,
-                                                        lease_duration, description)
-                                    {
-                                        Ok(()) => return Ok(local_addr.port()),
-                                        Err(ErrorResponse(AddPortError::ActionNotAuthorized))
-                                            => return Err(ErrorResponse(AddAnyPortError::ActionNotAuthorized)),
-                                        Err(ErrorResponse(AddPortError::ConflictInMappingEntry))
-                                            => return Err(ErrorResponse(AddAnyPortError::ExternalPortInUse)),
-                                        Err(ErrorResponse(AddPortError::SamePortValuesRequired)) |
-                                        Err(ErrorResponse(AddPortError::WildCardNotPermittedInExtPort))
-                                            => return Err(InvalidResponse),
-                                        Err(ErrorResponse(AddPortError::OnlyPermanentLeasesSupported))
-                                            => return Err(ErrorResponse(AddAnyPortError::OnlyPermanentLeasesSupported)),
-                                        Err(ErrorResponse(AddPortError::ErrorString(s)))
-                                            => return Err(ErrorResponse(AddAnyPortError::ErrorString(s))),
-                                        Err(HttpError(e)) => return Err(HttpError(e)),
-                                        Err(IoError(e)) => return Err(IoError(e)),
-                                        Err(InvalidResponse) => return Err(InvalidResponse),
-                                    }
-                                },
-                                Err(ErrorResponse(AddPortError::WildCardNotPermittedInExtPort))
-                                    => return Err(InvalidResponse),
-                                Err(ErrorResponse(AddPortError::OnlyPermanentLeasesSupported))
-                                    => return Err(ErrorResponse(AddAnyPortError::OnlyPermanentLeasesSupported)),
-                                Err(ErrorResponse(AddPortError::ErrorString(s)))
-                                    => return Err(ErrorResponse(AddAnyPortError::ErrorString(s))),
-                                Err(HttpError(e)) => return Err(HttpError(e)),
-                                Err(IoError(e)) => return Err(IoError(e)),
-                                Err(InvalidResponse) => return Err(InvalidResponse),
+            // The router doesn't know the AddAnyPortMapping method. Try using AddPortMapping
+            // instead.
+            Err(RequestError::ErrorCode(401, _)) => {
+                // Try a bunch of random ports.
+                for _attempt in 0..20 {
+                    let external_port = port_range.ind_sample(&mut rng);
+                    match self.add_port_mapping(protocol, external_port, local_addr, lease_duration, description) {
+                        Ok(()) => return Ok(external_port),
+                        Err(RequestError::ErrorCode(605, _)) => return Err(AddAnyPortError::DescriptionTooLong),
+                        Err(RequestError::ErrorCode(606, _)) => return Err(AddAnyPortError::ActionNotAuthorized),
+                        Err(RequestError::ErrorCode(718, _)) => continue,
+                        Err(RequestError::ErrorCode(724, _)) => {
+                            return match self.add_port_mapping(protocol, local_addr.port(), local_addr, lease_duration, description) {
+                                Ok(()) => Ok(local_addr.port()),
+                                Err(RequestError::ErrorCode(606, _)) => Err(AddAnyPortError::ActionNotAuthorized),
+                                Err(RequestError::ErrorCode(718, _)) => Err(AddAnyPortError::ExternalPortInUse),
+                                Err(RequestError::ErrorCode(725, _)) => Err(AddAnyPortError::OnlyPermanentLeasesSupported),
+                                Err(e) => Err(AddAnyPortError::RequestError(e)),
                             }
-                        }
-                        return Err(ErrorResponse(AddAnyPortError::ActionNotAuthorized));
-                    },
-                    "Action not authorized" => return Err(ErrorResponse(AddAnyPortError::ActionNotAuthorized)),
-                    "NoPortMapsAvailable" => return Err(ErrorResponse(AddAnyPortError::NoPortsAvailable)),
-                    d => return Err(ErrorResponse(AddAnyPortError::ErrorString(From::from(d)))),
-                },
-                None => return Err(InvalidResponse),
-            };
+                        },
+                        Err(RequestError::ErrorCode(725, _)) => return Err(AddAnyPortError::OnlyPermanentLeasesSupported),
+                        Err(e) => return Err(AddAnyPortError::RequestError(e)),
+                    }
+                }
+                // The only way we can get here is if the router kept returning 718 (port in use)
+                // for all the ports we tried.
+                Err(AddAnyPortError::NoPortsAvailable)
+            },
+            Err(RequestError::ErrorCode(605, _)) => Err(AddAnyPortError::DescriptionTooLong),
+            Err(RequestError::ErrorCode(606, _)) => Err(AddAnyPortError::ActionNotAuthorized),
+            Err(RequestError::ErrorCode(728, _)) => Err(AddAnyPortError::NoPortsAvailable),
+            Err(e) => Err(AddAnyPortError::RequestError(e)),
         }
-        Err(InvalidResponse)
     }
 
+    fn add_port_mapping(&self, protocol: PortMappingProtocol,
+                        external_port: u16, local_addr: SocketAddrV4, lease_duration: u32,
+                        description: &str) -> Result<(), RequestError> {
 
-    /// Add a port mapping.
-    ///
-    /// The local_addr is the address where the traffic is sent to.
-    /// The lease_duration parameter is in seconds. A value of 0 is infinite.
-    pub fn add_port(&self, protocol: PortMappingProtocol,
-                    external_port: u16, local_addr: SocketAddrV4, lease_duration: u32,
-                    description: &str) -> Result<(), RequestError<AddPortError>> {
-        use RequestError::*;
-        let url = format!("{}", self);
+        let header = "\"urn:schemas-upnp-org:service:WANIPConnection:1#AddPortMapping\"";
         let body = format!("<?xml version=\"1.0\"?>
         <s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">
         <s:Body>
@@ -490,47 +484,38 @@ impl Gateway {
         </s:Envelope>
         ", protocol, external_port, local_addr.ip(),
            local_addr.port(), lease_duration, description);
+        try!(self.perform_request(header, &*body, "AddPortMappingResponse"));
+        Ok(())
+    }
 
-        let text = try!(soap::send(&url, soap::Action::new(ADD_PORT_ACTION), &body));
-
-        let xml = match xmltree::Element::parse(text.as_bytes()) {
-            Ok(xml) => xml,
-            Err(..) => return Err(InvalidResponse),
-        };
-
-        let body = match xml.get_child("Body")
-        {
-            Some(body) => body,
-            None => return Err(InvalidResponse),
-        };
-        if let Some(..) = body.get_child("AddPortMappingResponse") {
-            return Ok(());
-        };
-        if let Some(fault) = body.get_child("Fault") {
-            match fault.get_child("detail")
-                       .and_then(|e| e.get_child("UPnPError"))
-                       .and_then(|e| e.get_child("errorDescription"))
-                       .and_then(|e| e.text.as_ref())
-            {
-                Some(description) => match &description[..] {
-                    "Action not authorized" => return Err(ErrorResponse(AddPortError::ActionNotAuthorized)),
-                    "WildCardNotPermittedInExtPort" => return Err(ErrorResponse(AddPortError::WildCardNotPermittedInExtPort)),
-                    "ConflictInMappingEntry" => return Err(ErrorResponse(AddPortError::ConflictInMappingEntry)),
-                    "SamePortValuesRequired" => return Err(ErrorResponse(AddPortError::SamePortValuesRequired)),
-                    "OnlyPermanentLeasesSupported" => return Err(ErrorResponse(AddPortError::OnlyPermanentLeasesSupported)),
-                    d => return Err(ErrorResponse(AddPortError::ErrorString(From::from(d)))),
-                },
-                None => return Err(InvalidResponse),
-            };
+    /// Add a port mapping.
+    ///
+    /// The local_addr is the address where the traffic is sent to.
+    /// The lease_duration parameter is in seconds. A value of 0 is infinite.
+    pub fn add_port(&self, protocol: PortMappingProtocol,
+                    external_port: u16, local_addr: SocketAddrV4, lease_duration: u32,
+                    description: &str) -> Result<(), AddPortError> {
+        if external_port == 0 {
+            return Err(AddPortError::ExternalPortZeroInvalid);
         }
-        Err(InvalidResponse)
+        if local_addr.port() == 0 {
+            return Err(AddPortError::InternalPortZeroInvalid);
+        }
+        match self.add_port_mapping(protocol, external_port, local_addr, lease_duration, description) {
+            Ok(()) => Ok(()),
+            Err(RequestError::ErrorCode(605, _)) => Err(AddPortError::DescriptionTooLong),
+            Err(RequestError::ErrorCode(606, _)) => Err(AddPortError::ActionNotAuthorized),
+            Err(RequestError::ErrorCode(718, _)) => Err(AddPortError::PortInUse),
+            Err(RequestError::ErrorCode(724, _)) => Err(AddPortError::SamePortValuesRequired),
+            Err(RequestError::ErrorCode(725, _)) => Err(AddPortError::OnlyPermanentLeasesSupported),
+            Err(e) => Err(AddPortError::RequestError(e)),
+        }
     }
 
     /// Remove a port mapping.
     pub fn remove_port(&self, protocol: PortMappingProtocol,
-                       external_port: u16) -> Result<(), RequestError<RemovePortError>> {
-        use RequestError::*;
-        let url = format!("{}", self);
+                       external_port: u16) -> Result<(), RemovePortError> {
+        let header = "\"urn:schemas-upnp-org:service:WANIPConnection:1#DeletePortMapping\"";
         let body = format!("<?xml version=\"1.0\"?>
         <s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">
         <s:Body>
@@ -544,36 +529,12 @@ impl Gateway {
         </s:Envelope>
         ", protocol, external_port);
 
-        let text = try!(soap::send(&url, soap::Action::new(DELETE_PORT_ACTION), &body));
-
-        let xml = match xmltree::Element::parse(text.as_bytes()) {
-            Ok(xml) => xml,
-            Err(..) => return Err(InvalidResponse),
-        };
-
-        let body = match xml.get_child("Body")
-        {
-            Some(body) => body,
-            None => return Err(InvalidResponse),
-        };
-        if let Some(..) = body.get_child("DeletePortMappingResponse") {
-            return Ok(());
-        };
-        if let Some(fault) = body.get_child("Fault") {
-            match fault.get_child("detail")
-                       .and_then(|e| e.get_child("UPnPError"))
-                       .and_then(|e| e.get_child("errorDescription"))
-                       .and_then(|e| e.text.as_ref())
-            {
-                Some(description) => match &description[..] {
-                    "Action not authorized" => return Err(ErrorResponse(RemovePortError::ActionNotAuthorized)),
-                    "NoSuchEntryInArray" => return Err(ErrorResponse(RemovePortError::NoSuchPortMapping)),
-                    d => return Err(ErrorResponse(RemovePortError::ErrorString(From::from(d)))),
-                },
-                None => return Err(InvalidResponse),
-            };
+        match self.perform_request(header, &*body, "DeletePortMappingResponse") {
+            Ok(..) => Ok(()),
+            Err(RequestError::ErrorCode(606, _)) => Err(RemovePortError::ActionNotAuthorized),
+            Err(RequestError::ErrorCode(714, _)) => Err(RemovePortError::NoSuchPortMapping),
+            Err(e) => Err(RemovePortError::RequestError(e)),
         }
-        Err(InvalidResponse)
     }
 }
 
@@ -582,17 +543,4 @@ impl fmt::Display for Gateway {
         write!(f, "http://{}{}", self.addr, self.control_url)
     }
 }
-
-
-// Content of the get external ip SOAPAction request header.
-const GET_EXTERNAL_IP_ACTION: &'static str = "\"urn:schemas-upnp-org:service:WANIPConnection:1#GetExternalIPAddress\"";
-
-// Content of the add port mapping SOAPAction request header.
-const ADD_PORT_ACTION: &'static str = "\"urn:schemas-upnp-org:service:WANIPConnection:1#AddPortMapping\"";
-
-// Content of the add any port mapping SOAPAction request header.
-const ADD_ANY_PORT_ACTION: &'static str = "\"urn:schemas-upnp-org:service:WANIPConnection:1#AddAnyPortMapping\"";
-
-// Content of the delete port mapping SOAPAction request header.
-const DELETE_PORT_ACTION: &'static str = "\"urn:schemas-upnp-org:service:WANIPConnection:1#DeletePortMapping\"";
 

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -1,35 +1,201 @@
 use std::io;
 use std::net::{Ipv4Addr, SocketAddrV4};
 use std::fmt;
+use std;
 
 use hyper;
-use regex::Regex;
+use xmltree;
 
 use soap;
 
 /// Errors that can occur when sending the request to the gateway.
 #[derive(Debug)]
-pub enum RequestError {
+pub enum RequestError<E: fmt::Debug> {
     /// Http/Hyper error
     HttpError(hyper::Error),
     /// Unable to process the response
     InvalidResponse,
     /// IO Error
     IoError(io::Error),
+    /// The gateway responded with an error.
+    ErrorResponse(E),
 }
 
+#[derive(Debug)]
+pub enum GetExternalIpError {
+    /// The client is not authorized to perform the operation.
+    ActionNotAuthorized,
+    /// The gateway returned an unrecognized error string.
+    ErrorString(String),
+}
 
-impl From<io::Error> for RequestError {
-    fn from(err: io::Error) -> RequestError {
+#[derive(Debug)]
+pub enum RemovePortError {
+    /// The client is not authorized to perform the operation.
+    ActionNotAuthorized,
+    /// No such port mapping.
+    NoSuchPortMapping,
+    /// The gateway returned an unrecognized error string.
+    ErrorString(String),
+}
+
+/// Errors returned by the gateway when trying to add a port.
+#[derive(Debug)]
+pub enum AddPortError {
+    /// The client is not authorized to perform the operation.
+    ActionNotAuthorized,
+    /// External port number 0 (any port) is considered invalid by the gateway.
+    WildCardNotPermittedInExtPort,
+    /// The requested mapping conflicts with a mapping assigned to another client.
+    ConflictInMappingEntry,
+    /// This gateway requires that the requested internal and external ports are the same.
+    SamePortValuesRequired,
+    /// This gateway only supports permanent leases (ie. a `lease_duration` of 0).
+    OnlyPermanentLeasesSupported,
+    /// The gateway returned an unrecognized error string.
+    ErrorString(String),
+}
+
+impl<E: fmt::Debug> From<io::Error> for RequestError<E> {
+    fn from(err: io::Error) -> RequestError<E> {
         RequestError::IoError(err)
     }
 }
 
-impl From<soap::Error> for RequestError {
-    fn from(err: soap::Error) -> RequestError {
+impl<E: fmt::Debug> From<soap::Error> for RequestError<E> {
+    fn from(err: soap::Error) -> RequestError<E> {
         match err {
             soap::Error::HttpError(e) => RequestError::HttpError(e),
             soap::Error::IoError(e) => RequestError::IoError(e),
+        }
+    }
+}
+
+impl<E: fmt::Debug + fmt::Display> fmt::Display for RequestError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            RequestError::HttpError(ref e) => write!(f, "Http error. {}", e),
+            RequestError::InvalidResponse => write!(f, "Invalid response from gateway."),
+            RequestError::IoError(ref e) => write!(f, "IO error. {}", e),
+            RequestError::ErrorResponse(ref e) => write!(f, "The gateway responded with an error. {}", e),
+        }
+    }
+}
+
+impl<E: std::error::Error> std::error::Error for RequestError<E> {
+    fn cause(&self) -> Option<&std::error::Error> {
+        match *self {
+            RequestError::HttpError(ref e)     => Some(e),
+            RequestError::InvalidResponse      => None,
+            RequestError::IoError(ref e)       => Some(e),
+            RequestError::ErrorResponse(ref e) => Some(e),
+        }
+    }
+
+    fn description(&self) -> &str {
+        match *self {
+            RequestError::HttpError(..)     => "Http error",
+            RequestError::InvalidResponse   => "Invalid response",
+            RequestError::IoError(..)       => "IO error",
+            RequestError::ErrorResponse(..) => "Error response",
+        }
+    }
+}
+
+impl fmt::Display for GetExternalIpError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            GetExternalIpError::ActionNotAuthorized
+                => write!(f, "The client is not authorized to remove the port"),
+            GetExternalIpError::ErrorString(ref s)
+                => write!(f, "The gateway returned an unrecognized error string: \"{}\"", s),
+        }
+    }
+}
+
+impl std::error::Error for GetExternalIpError {
+    fn cause(&self) -> Option<&std::error::Error> {
+        None
+    }
+
+    fn description(&self) -> &str {
+        match *self {
+            GetExternalIpError::ActionNotAuthorized
+                => "The client is not authorized to remove the port",
+            GetExternalIpError::ErrorString(ref s)
+                => &s[..],
+        }
+    }
+}
+
+impl fmt::Display for RemovePortError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            RemovePortError::ActionNotAuthorized
+                => write!(f, "The client is not authorized to remove the port"),
+            RemovePortError::NoSuchPortMapping
+                => write!(f, "The port was not mapped"),
+            RemovePortError::ErrorString(ref s)
+                => write!(f, "The gateway returned an unrecognized error string: \"{}\"", s),
+        }
+    }
+}
+
+impl std::error::Error for RemovePortError {
+    fn cause(&self) -> Option<&std::error::Error> {
+        None
+    }
+
+    fn description(&self) -> &str {
+        match *self {
+            RemovePortError::ActionNotAuthorized
+                => "The client is not authorized to remove the port",
+            RemovePortError::NoSuchPortMapping
+                => "The port was not mapped",
+            RemovePortError::ErrorString(ref s)
+                => &s[..],
+        }
+    }
+}
+
+impl fmt::Display for AddPortError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            AddPortError::ActionNotAuthorized
+                => write!(f, "The client is not authorized to map this port."),
+            AddPortError::WildCardNotPermittedInExtPort
+                => write!(f, "External port number 0 (any port) is considered invalid by the gateway."),
+            AddPortError::ConflictInMappingEntry
+                => write!(f, "The requested mapping conflicts with a mapping assigned to another client."),
+            AddPortError::SamePortValuesRequired
+                => write!(f, "This gateway requires that the requested internal and external ports are the same."),
+            AddPortError::OnlyPermanentLeasesSupported
+                => write!(f, "This gateway only supports permanent leases (ie. a `lease_duration` of 0),"),
+            AddPortError::ErrorString(ref s)
+                => write!(f, "The gateway returned an unrecognized error string: \"{}\"", s),
+        }
+    }
+}
+
+impl std::error::Error for AddPortError {
+    fn cause(&self) -> Option<&std::error::Error> {
+        None
+    }
+
+    fn description(&self) -> &str {
+        match *self {
+            AddPortError::ActionNotAuthorized
+                => "The client is not authorized to map this port.",
+            AddPortError::WildCardNotPermittedInExtPort
+                => "External port number 0 (any port) is considered invalid by the gateway.",
+            AddPortError::ConflictInMappingEntry
+                => "The requested mapping conflicts with a mapping assigned to another client.",
+            AddPortError::SamePortValuesRequired
+                => "This gateway requires that the requested internal and external ports are the same.",
+            AddPortError::OnlyPermanentLeasesSupported
+                => "This gateway only supports permanent leases (ie. a `lease_duration` of 0),",
+            AddPortError::ErrorString(ref s)
+                => &s[..],
         }
     }
 }
@@ -52,22 +218,8 @@ impl fmt::Display for PortMappingProtocol {
     }
 }
 
-// Extract the address from the text.
-fn extract_address(text: &str) -> Result<Ipv4Addr, RequestError> {
-    let re = Regex::new(r"<NewExternalIPAddress>(\d+\.\d+\.\d+\.\d+)</NewExternalIPAddress>").unwrap();
-    match re.captures(text) {
-        None => Err(RequestError::InvalidResponse),
-        Some(cap) => {
-            match cap.at(1) {
-                None => Err(RequestError::InvalidResponse),
-                Some(ip) => Ok(ip.parse::<Ipv4Addr>().unwrap()),
-            }
-        },
-    }
-}
-
 /// This structure represents a gateway found by the search functions.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub struct Gateway {
     /// Socket address of the gateway
     pub addr: SocketAddrV4,
@@ -78,8 +230,8 @@ pub struct Gateway {
 impl Gateway {
 
     /// Get the external IP address of the gateway.
-    pub fn get_external_ip(&self) -> Result<Ipv4Addr, RequestError> {
-        //let addr = gateway.addr.clone();
+    pub fn get_external_ip(&self) -> Result<Ipv4Addr, RequestError<GetExternalIpError>> {
+        use RequestError::*;
         let url = format!("{}", self);
         let body = "<?xml version=\"1.0\"?>
         <SOAP-ENV:Envelope SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\">
@@ -90,7 +242,42 @@ impl Gateway {
         </SOAP-ENV:Envelope>";
 
         let text = try!(soap::send(&url, soap::Action::new(GET_EXTERNAL_IP_ACTION), body));
-        extract_address(&text)
+
+        let xml = match xmltree::Element::parse(text.as_bytes()) {
+            Ok(xml) => xml,
+            Err(..) => return Err(InvalidResponse),
+        };
+
+        let body = match xml.get_child("Body")
+        {
+            Some(body) => body,
+            None => return Err(InvalidResponse),
+        };
+        if let Some(ext_ip) = body.get_child("GetExternalIPAddressResponse")
+                                  .and_then(|e| e.get_child("NewExternalIPAddress"))
+        {
+            match ext_ip.text {
+                Some(ref t) => match t.parse::<Ipv4Addr>() {
+                    Ok(ipv4_addr) => return Ok(ipv4_addr),
+                    Err(..) => return Err(InvalidResponse),
+                },
+                None => return Err(InvalidResponse),
+            }
+        };
+        if let Some(fault) = body.get_child("Fault") {
+            match fault.get_child("detail")
+                       .and_then(|e| e.get_child("UPnPError"))
+                       .and_then(|e| e.get_child("errorDescription"))
+                       .and_then(|e| e.text.as_ref())
+            {
+                Some(description) => match &description[..] {
+                    "Action not authorized" => return Err(ErrorResponse(GetExternalIpError::ActionNotAuthorized)),
+                    d => return Err(ErrorResponse(GetExternalIpError::ErrorString(From::from(d)))),
+                },
+                None => return Err(InvalidResponse),
+            };
+        }
+        Err(InvalidResponse)
     }
 
     /// Add a port mapping.
@@ -99,7 +286,8 @@ impl Gateway {
     /// The lease_duration parameter is in seconds. A value of 0 is infinite.
     pub fn add_port(&self, protocol: PortMappingProtocol,
                     external_port: u16, local_addr: SocketAddrV4, lease_duration: u32,
-                    description: &str) -> Result<(), RequestError> {
+                    description: &str) -> Result<(), RequestError<AddPortError>> {
+        use RequestError::*;
         let url = format!("{}", self);
         let body = format!("<?xml version=\"1.0\"?>
         <s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">
@@ -121,17 +309,43 @@ impl Gateway {
 
         let text = try!(soap::send(&url, soap::Action::new(ADD_PORT_ACTION), &body));
 
-        let re = Regex::new("u:AddPortMappingResponse").unwrap();
-        if re.is_match(&text) {
-            Ok(())
-        } else {
-            Err(RequestError::InvalidResponse)
+        let xml = match xmltree::Element::parse(text.as_bytes()) {
+            Ok(xml) => xml,
+            Err(..) => return Err(InvalidResponse),
+        };
+
+        let body = match xml.get_child("Body")
+        {
+            Some(body) => body,
+            None => return Err(InvalidResponse),
+        };
+        if let Some(..) = body.get_child("AddPortMappingResponse") {
+            return Ok(());
+        };
+        if let Some(fault) = body.get_child("Fault") {
+            match fault.get_child("detail")
+                       .and_then(|e| e.get_child("UPnPError"))
+                       .and_then(|e| e.get_child("errorDescription"))
+                       .and_then(|e| e.text.as_ref())
+            {
+                Some(description) => match &description[..] {
+                    "Action not authorized" => return Err(ErrorResponse(AddPortError::ActionNotAuthorized)),
+                    "WildCardNotPermittedInExtPort" => return Err(ErrorResponse(AddPortError::WildCardNotPermittedInExtPort)),
+                    "ConflictInMappingEntry" => return Err(ErrorResponse(AddPortError::ConflictInMappingEntry)),
+                    "SamePortValuesRequired" => return Err(ErrorResponse(AddPortError::SamePortValuesRequired)),
+                    "OnlyPermanentLeasesSupported" => return Err(ErrorResponse(AddPortError::OnlyPermanentLeasesSupported)),
+                    d => return Err(ErrorResponse(AddPortError::ErrorString(From::from(d)))),
+                },
+                None => return Err(InvalidResponse),
+            };
         }
+        Err(InvalidResponse)
     }
 
     /// Remove a port mapping.
     pub fn remove_port(&self, protocol: PortMappingProtocol,
-                       external_port: u16) -> Result<(), RequestError> {
+                       external_port: u16) -> Result<(), RequestError<RemovePortError>> {
+        use RequestError::*;
         let url = format!("{}", self);
         let body = format!("<?xml version=\"1.0\"?>
         <s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">
@@ -148,15 +362,35 @@ impl Gateway {
 
         let text = try!(soap::send(&url, soap::Action::new(DELETE_PORT_ACTION), &body));
 
-        let re = Regex::new("u:DeletePortMappingResponse").unwrap();
-        if re.is_match(&text) {
-            Ok(())
-        } else {
-            Err(RequestError::InvalidResponse)
+        let xml = match xmltree::Element::parse(text.as_bytes()) {
+            Ok(xml) => xml,
+            Err(..) => return Err(InvalidResponse),
+        };
+
+        let body = match xml.get_child("Body")
+        {
+            Some(body) => body,
+            None => return Err(InvalidResponse),
+        };
+        if let Some(..) = body.get_child("DeletePortMappingResponse") {
+            return Ok(());
+        };
+        if let Some(fault) = body.get_child("Fault") {
+            match fault.get_child("detail")
+                       .and_then(|e| e.get_child("UPnPError"))
+                       .and_then(|e| e.get_child("errorDescription"))
+                       .and_then(|e| e.text.as_ref())
+            {
+                Some(description) => match &description[..] {
+                    "Action not authorized" => return Err(ErrorResponse(RemovePortError::ActionNotAuthorized)),
+                    "NoSuchEntryInArray" => return Err(ErrorResponse(RemovePortError::NoSuchPortMapping)),
+                    d => return Err(ErrorResponse(RemovePortError::ErrorString(From::from(d)))),
+                },
+                None => return Err(InvalidResponse),
+            };
         }
+        Err(InvalidResponse)
     }
-
-
 }
 
 impl fmt::Display for Gateway {
@@ -174,3 +408,4 @@ const ADD_PORT_ACTION: &'static str = "\"urn:schemas-upnp-org:service:WANIPConne
 
 // Content of the delete port mapping SOAPAction request header.
 const DELETE_PORT_ACTION: &'static str = "\"urn:schemas-upnp-org:service:WANIPConnection:1#DeletePortMapping\"";
+

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -325,8 +325,8 @@ impl Gateway {
             return Ok((text, ok))
         }
         let upnp_error = match body.get_child("Fault")
-                              .and_then(|e| e.get_child("UPnPError"))
                               .and_then(|e| e.get_child("detail"))
+                              .and_then(|e| e.get_child("UPnPError"))
         {
             Some(upnp_error) => upnp_error,
             None => return Err(RequestError::InvalidResponse(text)),
@@ -522,8 +522,7 @@ impl Gateway {
             <u:DeletePortMapping xmlns:u=\"urn:schemas-upnp-org:service:WANIPConnection:1\">
                 <NewProtocol>{}</NewProtocol>
                 <NewExternalPort>{}</NewExternalPort>
-                <NewRemoteHost>
-                </NewRemoteHost>
+                <NewRemoteHost></NewRemoteHost>
             </u:DeletePortMapping>
         </s:Body>
         </s:Envelope>

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -2,10 +2,11 @@ use std::io;
 use std::net::{Ipv4Addr, SocketAddrV4};
 use std::fmt;
 use std;
+use rand::distributions::IndependentSample;
 
 use hyper;
 use xmltree;
-
+use rand;
 use soap;
 
 /// Errors that can occur when sending the request to the gateway.
@@ -39,6 +40,21 @@ pub enum RemovePortError {
     ErrorString(String),
 }
 
+#[derive(Debug)]
+pub enum AddAnyPortError {
+    /// The client is not authorized to perform the operation.
+    ActionNotAuthorized,
+    /// The gateway does not have any free ports.
+    NoPortsAvailable,
+    /// The gateway can only map internal ports to same-numbered external ports
+    /// and this external port is in use.
+    ExternalPortInUse,
+    /// The gateway only supports permanent leases (ie. a `lease_duration` of 0).
+    OnlyPermanentLeasesSupported,
+    /// The gateway returned an unrecognized error string.
+    ErrorString(String),
+}
+
 /// Errors returned by the gateway when trying to add a port.
 #[derive(Debug)]
 pub enum AddPortError {
@@ -48,9 +64,9 @@ pub enum AddPortError {
     WildCardNotPermittedInExtPort,
     /// The requested mapping conflicts with a mapping assigned to another client.
     ConflictInMappingEntry,
-    /// This gateway requires that the requested internal and external ports are the same.
+    /// The gateway requires that the requested internal and external ports are the same.
     SamePortValuesRequired,
-    /// This gateway only supports permanent leases (ie. a `lease_duration` of 0).
+    /// The gateway only supports permanent leases (ie. a `lease_duration` of 0).
     OnlyPermanentLeasesSupported,
     /// The gateway returned an unrecognized error string.
     ErrorString(String),
@@ -158,6 +174,44 @@ impl std::error::Error for RemovePortError {
     }
 }
 
+impl fmt::Display for AddAnyPortError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            AddAnyPortError::ActionNotAuthorized
+                => write!(f, "The client is not authorized to remove the port"),
+            AddAnyPortError::NoPortsAvailable
+                => write!(f, "The gateway does not have any free ports"),
+            AddAnyPortError::OnlyPermanentLeasesSupported
+                => write!(f, "The gateway only supports permanent leases (ie. a `lease_duration` of 0),"),
+            AddAnyPortError::ExternalPortInUse
+                => write!(f, "The gateway can only map internal ports to same-numbered external ports and this external port is in use."),
+            AddAnyPortError::ErrorString(ref s)
+                => write!(f, "The gateway returned an unrecognized error string: \"{}\"", s),
+        }
+    }
+}
+
+impl std::error::Error for AddAnyPortError {
+    fn cause(&self) -> Option<&std::error::Error> {
+        None
+    }
+
+    fn description(&self) -> &str {
+        match *self {
+            AddAnyPortError::ActionNotAuthorized
+                => "The client is not authorized to remove the port",
+            AddAnyPortError::NoPortsAvailable
+                => "The gateway does not have any free ports",
+            AddAnyPortError::OnlyPermanentLeasesSupported
+                => "The gateway only supports permanent leases (ie. a `lease_duration` of 0),",
+            AddAnyPortError::ExternalPortInUse
+                => "The gateway can only map internal ports to same-numbered external ports and this external port is in use.",
+            AddAnyPortError::ErrorString(ref s)
+                => &s[..],
+        }
+    }
+}
+
 impl fmt::Display for AddPortError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -168,9 +222,9 @@ impl fmt::Display for AddPortError {
             AddPortError::ConflictInMappingEntry
                 => write!(f, "The requested mapping conflicts with a mapping assigned to another client."),
             AddPortError::SamePortValuesRequired
-                => write!(f, "This gateway requires that the requested internal and external ports are the same."),
+                => write!(f, "The gateway requires that the requested internal and external ports are the same."),
             AddPortError::OnlyPermanentLeasesSupported
-                => write!(f, "This gateway only supports permanent leases (ie. a `lease_duration` of 0),"),
+                => write!(f, "The gateway only supports permanent leases (ie. a `lease_duration` of 0),"),
             AddPortError::ErrorString(ref s)
                 => write!(f, "The gateway returned an unrecognized error string: \"{}\"", s),
         }
@@ -191,9 +245,9 @@ impl std::error::Error for AddPortError {
             AddPortError::ConflictInMappingEntry
                 => "The requested mapping conflicts with a mapping assigned to another client.",
             AddPortError::SamePortValuesRequired
-                => "This gateway requires that the requested internal and external ports are the same.",
+                => "The gateway requires that the requested internal and external ports are the same.",
             AddPortError::OnlyPermanentLeasesSupported
-                => "This gateway only supports permanent leases (ie. a `lease_duration` of 0),",
+                => "The gateway only supports permanent leases (ie. a `lease_duration` of 0),",
             AddPortError::ErrorString(ref s)
                 => &s[..],
         }
@@ -279,6 +333,136 @@ impl Gateway {
         }
         Err(InvalidResponse)
     }
+
+    /// Add a port mapping.with any external port.
+    ///
+    /// The local_addr is the address where the traffic is sent to.
+    /// The lease_duration parameter is in seconds. A value of 0 is infinite.
+    ///
+    /// # Returns
+    ///
+    /// The external port that was mapped on success. Otherwise an error.
+    pub fn add_any_port(&self, protocol: PortMappingProtocol,
+                        local_addr: SocketAddrV4,
+                        lease_duration: u32, description: &str)
+            -> Result<u16, RequestError<AddAnyPortError>>
+    {
+        // This function first attempts to call AddAnyPortMapping on the IGD with a random port
+        // number. If that fails due to the method being unknown it attempts to call AddPortMapping
+        // instead with a random port number. If that fails due to ActionNotAuthorized or
+        // ConflictInMappingEntry it retrys with another port up to a maximum of 20 times. If it
+        // fails due to SamePortValuesRequired it retrys once with the same port values.
+
+        use RequestError::*;
+
+        let port_range = rand::distributions::Range::new(32768u16, 65535u16);
+        let mut rng = rand::thread_rng();
+        let external_port = port_range.ind_sample(&mut rng);
+
+        let url = format!("{}", self);
+        let body = format!("<?xml version=\"1.0\"?>
+        <s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">
+        <s:Body>
+            <u:AddAnyPortMapping xmlns:u=\"urn:schemas-upnp-org:service:WANIPConnection:1\">
+                <NewProtocol>{}</NewProtocol>
+                <NewExternalPort>{}</NewExternalPort>
+                <NewInternalClient>{}</NewInternalClient>
+                <NewInternalPort>{}</NewInternalPort>
+                <NewLeaseDuration>{}</NewLeaseDuration>
+                <NewPortMappingDescription>{}</NewPortMappingDescription>
+                <NewEnabled>1</NewEnabled>
+                <NewRemoteHost></NewRemoteHost>
+            </u:AddPortMapping>
+        </s:Body>
+        </s:Envelope>
+        ", protocol, external_port, local_addr.ip(),
+           local_addr.port(), lease_duration, description);
+
+        let text = try!(soap::send(&url, soap::Action::new(ADD_ANY_PORT_ACTION), &body));
+        println!("got text: {}", text);
+
+        let xml = match xmltree::Element::parse(text.as_bytes()) {
+            Ok(xml) => xml,
+            Err(..) => return Err(InvalidResponse),
+        };
+
+        let body = match xml.get_child("Body")
+        {
+            Some(body) => body,
+            None => return Err(InvalidResponse),
+        };
+        if let Some(ext_ip) = body.get_child("AddAnyPortMappingResponse")
+                                  .and_then(|e| e.get_child("NewReservedPort"))
+        {
+            match ext_ip.text {
+                Some(ref t) => match t.parse::<u16>() {
+                    Ok(port) => return Ok(port),
+                    Err(..) => return Err(InvalidResponse),
+                },
+                None => return Err(InvalidResponse),
+            }
+        };
+        if let Some(fault) = body.get_child("Fault") {
+            match fault.get_child("detail")
+                       .and_then(|e| e.get_child("UPnPError"))
+                       .and_then(|e| e.get_child("errorDescription"))
+                       .and_then(|e| e.text.as_ref())
+            {
+                Some(description) => match &description[..] {
+                    "InvalidAction" => {
+                        for _attempt in 0..20 {
+                            let external_port = port_range.ind_sample(&mut rng);
+                            match self.add_port(protocol, external_port, local_addr,
+                                                lease_duration, description)
+                            {
+                                Ok(()) => return Ok(external_port),
+                                Err(ErrorResponse(AddPortError::ActionNotAuthorized)) |
+                                Err(ErrorResponse(AddPortError::ConflictInMappingEntry))
+                                    => continue,
+                                Err(ErrorResponse(AddPortError::SamePortValuesRequired)) => {
+                                    match self.add_port(protocol, local_addr.port(), local_addr,
+                                                        lease_duration, description)
+                                    {
+                                        Ok(()) => return Ok(local_addr.port()),
+                                        Err(ErrorResponse(AddPortError::ActionNotAuthorized))
+                                            => return Err(ErrorResponse(AddAnyPortError::ActionNotAuthorized)),
+                                        Err(ErrorResponse(AddPortError::ConflictInMappingEntry))
+                                            => return Err(ErrorResponse(AddAnyPortError::ExternalPortInUse)),
+                                        Err(ErrorResponse(AddPortError::SamePortValuesRequired)) |
+                                        Err(ErrorResponse(AddPortError::WildCardNotPermittedInExtPort))
+                                            => return Err(InvalidResponse),
+                                        Err(ErrorResponse(AddPortError::OnlyPermanentLeasesSupported))
+                                            => return Err(ErrorResponse(AddAnyPortError::OnlyPermanentLeasesSupported)),
+                                        Err(ErrorResponse(AddPortError::ErrorString(s)))
+                                            => return Err(ErrorResponse(AddAnyPortError::ErrorString(s))),
+                                        Err(HttpError(e)) => return Err(HttpError(e)),
+                                        Err(IoError(e)) => return Err(IoError(e)),
+                                        Err(InvalidResponse) => return Err(InvalidResponse),
+                                    }
+                                },
+                                Err(ErrorResponse(AddPortError::WildCardNotPermittedInExtPort))
+                                    => return Err(InvalidResponse),
+                                Err(ErrorResponse(AddPortError::OnlyPermanentLeasesSupported))
+                                    => return Err(ErrorResponse(AddAnyPortError::OnlyPermanentLeasesSupported)),
+                                Err(ErrorResponse(AddPortError::ErrorString(s)))
+                                    => return Err(ErrorResponse(AddAnyPortError::ErrorString(s))),
+                                Err(HttpError(e)) => return Err(HttpError(e)),
+                                Err(IoError(e)) => return Err(IoError(e)),
+                                Err(InvalidResponse) => return Err(InvalidResponse),
+                            }
+                        }
+                        return Err(ErrorResponse(AddAnyPortError::ActionNotAuthorized));
+                    },
+                    "Action not authorized" => return Err(ErrorResponse(AddAnyPortError::ActionNotAuthorized)),
+                    "NoPortMapsAvailable" => return Err(ErrorResponse(AddAnyPortError::NoPortsAvailable)),
+                    d => return Err(ErrorResponse(AddAnyPortError::ErrorString(From::from(d)))),
+                },
+                None => return Err(InvalidResponse),
+            };
+        }
+        Err(InvalidResponse)
+    }
+
 
     /// Add a port mapping.
     ///
@@ -405,6 +589,9 @@ const GET_EXTERNAL_IP_ACTION: &'static str = "\"urn:schemas-upnp-org:service:WAN
 
 // Content of the add port mapping SOAPAction request header.
 const ADD_PORT_ACTION: &'static str = "\"urn:schemas-upnp-org:service:WANIPConnection:1#AddPortMapping\"";
+
+// Content of the add any port mapping SOAPAction request header.
+const ADD_ANY_PORT_ACTION: &'static str = "\"urn:schemas-upnp-org:service:WANIPConnection:1#AddAnyPortMapping\"";
 
 // Content of the delete port mapping SOAPAction request header.
 const DELETE_PORT_ACTION: &'static str = "\"urn:schemas-upnp-org:service:WANIPConnection:1#DeletePortMapping\"";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ extern crate hyper;
 extern crate regex;
 extern crate xml;
 extern crate xmltree;
+extern crate rand;
 
 // data structures
 pub use self::gateway::Gateway;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,10 @@ extern crate rand;
 pub use self::gateway::Gateway;
 pub use self::gateway::PortMappingProtocol;
 pub use self::gateway::RequestError;
+pub use self::gateway::GetExternalIpError;
+pub use self::gateway::RemovePortError;
+pub use self::gateway::AddPortError;
+pub use self::gateway::AddAnyPortError;
 
 // search of gateway
 pub use self::search::search_gateway;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 extern crate hyper;
 extern crate regex;
 extern crate xml;
+extern crate xmltree;
 
 // data structures
 pub use self::gateway::Gateway;

--- a/src/search.rs
+++ b/src/search.rs
@@ -2,6 +2,8 @@ use std::io;
 use std::net::{Ipv4Addr, SocketAddrV4};
 use std::net::UdpSocket;
 use std::str;
+use std::fmt;
+use std::error;
 use std::time::Duration;
 
 use hyper;
@@ -56,6 +58,40 @@ impl From<str::Utf8Error> for SearchError {
 impl From<XmlError> for SearchError {
     fn from(err: XmlError) -> SearchError {
         SearchError::XmlError(err)
+    }
+}
+
+impl fmt::Display for SearchError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            SearchError::HttpError(ref e) => write!(f, "HTTP error: {}", e),
+            SearchError::InvalidResponse  => write!(f, "Invalid response"),
+            SearchError::IoError(ref e)   => write!(f, "IO error: {}", e),
+            SearchError::Utf8Error(ref e) => write!(f, "UTF-8 error: {}", e),
+            SearchError::XmlError(ref e)  => write!(f, "XML error: {}", e),
+        }
+    }
+}
+
+impl error::Error for SearchError {
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            SearchError::HttpError(ref e) => Some(e),
+            SearchError::InvalidResponse  => None,
+            SearchError::IoError(ref e)   => Some(e),
+            SearchError::Utf8Error(ref e) => Some(e),
+            SearchError::XmlError(ref e)  => Some(e),
+        }
+    }
+
+    fn description(&self) -> &str {
+        match *self {
+            SearchError::HttpError(..)   => "HTTP error",
+            SearchError::InvalidResponse => "Invalid response",
+            SearchError::IoError(..)     => "IO error",
+            SearchError::Utf8Error(..)   => "UTF-8 error",
+            SearchError::XmlError(..)    => "XML error",
+        }
     }
 }
 


### PR DESCRIPTION
This PR parses the XML responses from the gateway and uses them to return more detailed error values. It also adds a new method, `Gateway::add_any_port` which tries to create a port mapping with a random external port. This method internally calls the `AddAnyPortMapping` IGD method, if the method isn't available it calls `add_port` repeatedly with random port values.