### PR TITLE
Add Gateway::get_any_address method.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "igd"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Simon Bernier St-Pierre <sbernierstpierre@gmail.com>"]
 description = "Internet Gateway Protocol client"
 homepage = "https://github.com/SBSTP/rust-igd"


### PR DESCRIPTION
This is a convenience method that just calls `get_external_ip` followed by
`add_any_port`.

Discussion welcome over whether `get_any_address` is a good name or whether the method should return it's own type.