### PR TITLE
updated hyper version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ xmltree = "0.3"
 rand = "0.3"
 
 [dependencies.hyper]
-version = "0.6.*"
+version = "0.8.*"
 default-features = false


### PR DESCRIPTION
in `0.8` serde is no longer required dependency