### PR TITLE
Fix add_any_port invalid xml

### DIFF
--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -442,7 +442,7 @@ impl Gateway {
                 <NewPortMappingDescription>{}</NewPortMappingDescription>
                 <NewEnabled>1</NewEnabled>
                 <NewRemoteHost></NewRemoteHost>
-            </u:AddPortMapping>
+            </u:AddAnyPortMapping>
         </s:Body>
         </s:Envelope>
         ", protocol, external_port, local_addr.ip(),


### PR DESCRIPTION
The invalid XML causes errors other than a 401 Invalid Action.