### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ license = "MIT"
 
 [dependencies]
 regex = "0.1.41"
-xml-rs = "0.1.25"
+xml-rs = "0.3"
 xmltree = "0.3"
 rand = "0.3"
 
 [dependencies.hyper]
-version = "0.8.*"
+version = "0.9"
 default-features = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub use self::search::SearchError;
 
 // re-export error types
 pub use hyper::Error as HttpError;
-pub use xml::common::Error as XmlError;
+pub use xml::reader::Error as XmlError;
 
 mod gateway;
 mod search;


### PR DESCRIPTION
Updates hyper to 0.9 (removes dependency on old `url`, which may cause a problem in the future due to github.com/servo/rust-url/issues/195), as well as the xml parser.