### PR TITLE
Ability to pick upnp control url

### DIFF
--- a/src/aio/search.rs
+++ b/src/aio/search.rs
@@ -90,7 +90,7 @@ impl SearchFuture {
     }
 
     // Process a control response to extract the control URL
-    fn handle_control_resp(addr: SocketAddr, resp: Bytes) -> Result<String, SearchError> {
+    fn handle_control_resp(addr: SocketAddr, resp: Bytes) -> Result<Vec<String>, SearchError> {
         debug!("handling control response from: {}", addr);
 
         // Create a cursor over the response data

--- a/src/aio/search.rs
+++ b/src/aio/search.rs
@@ -150,7 +150,7 @@ impl Future for SearchFuture {
 
                 match addr {
                     SocketAddr::V4(a) => {
-                        let g = Gateway::new(*a, url[0]);
+                        let g = Gateway::new(*a, url[0].clone());
                         return Ok(Async::Ready(g));
                     }
                     _ => warn!("unsupported IPv6 gateway response from addr: {}", addr),

--- a/src/aio/search.rs
+++ b/src/aio/search.rs
@@ -145,12 +145,12 @@ impl Future for SearchFuture {
 
             // Handle any responses
             if let Ok(url) = Self::handle_control_resp(*addr, resp) {
-                debug!("received control url from: {} (url: {})", addr, url);
-                *state = SearchState::Done(url.clone());
+                debug!("received control url from: {} (url: {:?})", addr, url);
+                *state = SearchState::Done(url[0].clone());
 
                 match addr {
                     SocketAddr::V4(a) => {
-                        let g = Gateway::new(*a, url);
+                        let g = Gateway::new(*a, url[0]);
                         return Ok(Async::Ready(g));
                     }
                     _ => warn!("unsupported IPv6 gateway response from addr: {}", addr),

--- a/src/search.rs
+++ b/src/search.rs
@@ -33,17 +33,64 @@ pub fn search_gateway(options: SearchOptions) -> Result<Gateway, SearchError> {
         let text = str::from_utf8(&buf[..read])?;
 
         let location = parsing::parse_search_result(text)?;
+
         if let Ok(control_url) = get_control_url(&location) {
-            return Ok(Gateway {
+            // Defaults to using the first control url.
+            if control_url.len() > 0{
+                return Ok(Gateway {
                 addr: location.0,
-                control_url: control_url,
-            });
+                control_url: control_url[0].clone(),
+                });
+            } else {
+                return Err(SearchError::InvalidResponse);
+            }
         }
     }
 }
 
-fn get_control_url(location: &(SocketAddrV4, String)) -> Result<String, SearchError> {
+pub fn get_control_urls(options: SearchOptions) -> Result<Vec<String>, SearchError> {
+    let socket = UdpSocket::bind(options.bind_addr)?;
+    socket.set_read_timeout(options.timeout)?;
+
+    socket.send_to(messages::SEARCH_REQUEST.as_bytes(), options.broadcast_address)?;
+
+    loop {
+        let mut buf = [0u8; 1500];
+        let (read, _) = socket.recv_from(&mut buf)?;
+        let text = str::from_utf8(&buf[..read])?;
+
+        let location = parsing::parse_search_result(text)?;
+
+        if let Ok(control_url) = get_control_url(&location) {
+            if control_url.len() > 0{
+                return Ok(control_url);
+            } else {
+                return Err(SearchError::InvalidResponse);
+            }
+        }
+    }
+}
+
+/*
+    A bit of an ugly temporary workaround, basically the idea is to use get_control_urls() and then call
+    search_gateway() with a valid control url. Allows the user to select the interface to use.
+*/
+pub fn get_gateway_with_control_url(options: SearchOptions, url: &str) -> Result<Gateway, SearchError>{
+    let mut gateway = search_gateway(options)?;
+    gateway.control_url = String::from(url);
+    Ok(gateway)
+}
+
+
+fn get_control_url(location: &(SocketAddrV4, String)) -> Result<Vec<String>, SearchError> {
     let url = format!("http://{}:{}{}", location.0.ip(), location.0.port(), location.1);
     let response = attohttpc::get(&url).send()?;
-    parsing::parse_control_url(&response.bytes()?[..])
+    let res = parsing::parse_control_url(&response.bytes()?[..]);
+    res
+}
+
+#[test]
+fn test_get_control_urls(){
+    // This test will fail if upnp is disabled on the default interface ( default gateway )
+    assert_eq!(get_control_urls(SearchOptions::default()).unwrap().len() > 0, true);
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -53,14 +53,12 @@ pub fn get_control_urls(options: SearchOptions) -> Result<Vec<String>, SearchErr
     socket.set_read_timeout(options.timeout)?;
 
     socket.send_to(messages::SEARCH_REQUEST.as_bytes(), options.broadcast_address)?;
-
     loop {
         let mut buf = [0u8; 1500];
         let (read, _) = socket.recv_from(&mut buf)?;
         let text = str::from_utf8(&buf[..read])?;
-
+    
         let location = parsing::parse_search_result(text)?;
-
         if let Ok(control_url) = get_control_url(&location) {
             if control_url.len() > 0{
                 return Ok(control_url);

--- a/src/search.rs
+++ b/src/search.rs
@@ -87,8 +87,8 @@ fn get_control_url(location: &(SocketAddrV4, String)) -> Result<Vec<String>, Sea
     res
 }
 
-#[test]
-fn test_get_control_urls(){
-    // This test will fail if upnp is disabled on the default interface ( default gateway )
-    assert_eq!(get_control_urls(SearchOptions::default()).unwrap().len() > 0, true);
-}
+// #[test]
+// fn test_get_control_urls(){
+//     // This test will fail if upnp is disabled on the default interface ( default gateway )
+//     assert_eq!(get_control_urls(SearchOptions::default()).unwrap().len() > 0, true);
+// }


### PR DESCRIPTION
Sorry for opening this again, in the previous code a check was done for ``urn:schemas-upnp-org:service:WANIPConnection:1`` ; That did not work on my router, I later added a check for a ``PPPIPConnection:1`` and only later realised that the trick was there could be multiple of these strings. 

I modified the code so that search_gateway defaults to the first one found, but added a function that can be used to create a Gateway using a particular control url. I tested this in different networks and it worked in those! :)