### PR TITLE
Make aio::Gateway struct fields public

### DIFF
--- a/src/aio/gateway.rs
+++ b/src/aio/gateway.rs
@@ -12,9 +12,9 @@ use crate::PortMappingProtocol;
 #[derive(Clone, Debug)]
 pub struct Gateway {
     /// Socket address of the gateway
-    addr: SocketAddrV4,
+    pub addr: SocketAddrV4,
     /// Control url of the device
-    control_url: String,
+    pub control_url: String,
 }
 
 impl Gateway {


### PR DESCRIPTION
For consistency with the synchronous version (`rust_igd::Gateway`), `rust_igd::aio::Gateway` struct fields should be public too. I don't know if there was any specific reason to make them private though, but a user needs to have access to the gateway address (e.g. to find their IP on LAN).