### PR TITLE
Use control schema for messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ xmltree = "0.10"
 rand = "0.7"
 attohttpc = { version = "0.10", default-features = false }
 url = "2"
+log = "0.4"
 futures = { version = "0.3", optional = true }
 tokio = { version = "0.2", optional = true , features = [ "udp", "macros" ]}
-log = { version = "0.4", optional = true }
 bytes = { version = "0.5", optional = true }
 http = {version = "0.2", optional = true }
 
@@ -36,7 +36,7 @@ simplelog = "0.7"
 
 [features]
 default = []
-aio = ["futures", "tokio", "hyper", "bytes", "log", "http"]
+aio = ["futures", "tokio", "hyper", "bytes", "http"]
 
 [[example]]
 name = "add_any_port"

--- a/src/aio/gateway.rs
+++ b/src/aio/gateway.rs
@@ -18,14 +18,6 @@ pub struct Gateway {
 }
 
 impl Gateway {
-    /// Create a new Gateway
-    pub fn new(addr: SocketAddrV4, control_url: String) -> Gateway {
-        Gateway {
-            addr: addr,
-            control_url: control_url,
-        }
-    }
-
     async fn perform_request(&self, header: &str, body: &str, ok: &str) -> Result<RequestReponse, RequestError> {
         let url = format!("{}", self);
         let text = soap::send_async(&url, soap::Action::new(header), body).await?;

--- a/src/aio/gateway.rs
+++ b/src/aio/gateway.rs
@@ -17,6 +17,8 @@ pub struct Gateway {
     pub root_url: String,
     /// Control url of the device
     pub control_url: String,
+    /// Url to get schema data from
+    pub control_schema_url: String,
 }
 
 impl Gateway {

--- a/src/aio/gateway.rs
+++ b/src/aio/gateway.rs
@@ -198,7 +198,9 @@ impl Gateway {
         self.perform_request(
             messages::ADD_PORT_MAPPING_HEADER,
             &messages::format_add_port_mapping_message(
-                self.control_schema.get("AddPortMapping").unwrap(),
+                self.control_schema
+                    .get("AddPortMapping")
+                    .ok_or(RequestError::UnsupportedAction("AddPortMapping".to_string()))?,
                 protocol,
                 external_port,
                 local_addr,
@@ -245,7 +247,11 @@ impl Gateway {
             .perform_request(
                 messages::DELETE_PORT_MAPPING_HEADER,
                 &messages::format_delete_port_message(
-                    self.control_schema.get("DeletePortMapping").unwrap(),
+                    self.control_schema
+                        .get("DeletePortMapping")
+                        .ok_or(RemovePortError::RequestError(RequestError::UnsupportedAction(
+                            "DeletePortMapping".to_string(),
+                        )))?,
                     protocol,
                     external_port,
                 ),

--- a/src/aio/gateway.rs
+++ b/src/aio/gateway.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::net::{Ipv4Addr, SocketAddrV4};
@@ -19,6 +20,8 @@ pub struct Gateway {
     pub control_url: String,
     /// Url to get schema data from
     pub control_schema_url: String,
+    /// Control schema for all actions
+    pub control_schema: HashMap<String, Vec<String>>,
 }
 
 impl Gateway {

--- a/src/aio/gateway.rs
+++ b/src/aio/gateway.rs
@@ -13,6 +13,8 @@ use crate::PortMappingProtocol;
 pub struct Gateway {
     /// Socket address of the gateway
     pub addr: SocketAddrV4,
+    /// Root url of the device
+    pub root_url: String,
     /// Control url of the device
     pub control_url: String,
 }

--- a/src/aio/search.rs
+++ b/src/aio/search.rs
@@ -160,7 +160,10 @@ impl Future for SearchFuture {
 
                 match addr {
                     SocketAddr::V4(a) => {
-                        let g = Gateway::new(*a, url);
+                        let g = Gateway {
+                            addr: *a,
+                            contorl_url: url,
+                        };
                         return Poll::Ready(Ok(g));
                     }
                     _ => warn!("unsupported IPv6 gateway response from addr: {}", addr),

--- a/src/aio/search.rs
+++ b/src/aio/search.rs
@@ -154,15 +154,15 @@ impl Future for SearchFuture {
             };
 
             // Handle any responses
-            if let Ok(url) = Self::handle_control_resp(*addr, resp) {
-                debug!("received control url from: {} (url: {})", addr, url);
+            if let Ok(control_url) = Self::handle_control_resp(*addr, resp) {
+                debug!("received control url from: {} (url: {})", addr, control_url);
                 *state = SearchState::Done(url.clone());
 
                 match addr {
                     SocketAddr::V4(a) => {
                         let g = Gateway {
                             addr: *a,
-                            contorl_url: url,
+                            control_url,
                         };
                         return Poll::Ready(Ok(g));
                     }

--- a/src/common/messages.rs
+++ b/src/common/messages.rs
@@ -22,6 +22,17 @@ pub const DELETE_PORT_MAPPING_HEADER: &'static str =
 pub const GET_GENERIC_PORT_MAPPING_ENTRY: &'static str =
     r#""urn:schemas-upnp-org:service:WANIPConnection:1#GetGenericPortMappingEntry""#;
 
+const MESSAGE_HEAD: &'static str = r#"<?xml version="1.0"?>
+<s:Envelope s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+<s:Body>"#;
+
+const MESSAGE_TAIL: &'static str = r#"</s:Body>
+</s:Envelope>"#;
+
+fn format_message(body: String) -> String {
+    format!("{}{}{}", MESSAGE_HEAD, body, MESSAGE_TAIL)
+}
+
 pub fn format_get_external_ip_message() -> String {
     format!(
         r#"<?xml version="1.0"?>
@@ -41,10 +52,8 @@ pub fn format_add_any_port_mapping_message(
     lease_duration: u32,
     description: &str,
 ) -> String {
-    format!("<?xml version=\"1.0\"?>
-<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">
-<s:Body>
-    <u:AddAnyPortMapping xmlns:u=\"urn:schemas-upnp-org:service:WANIPConnection:1\">
+    format_message(format!(
+        r#"<u:AddAnyPortMapping xmlns:u="urn:schemas-upnp-org:service:WANIPConnection:1">
         <NewProtocol>{}</NewProtocol>
         <NewExternalPort>{}</NewExternalPort>
         <NewInternalClient>{}</NewInternalClient>
@@ -53,16 +62,14 @@ pub fn format_add_any_port_mapping_message(
         <NewPortMappingDescription>{}</NewPortMappingDescription>
         <NewEnabled>1</NewEnabled>
         <NewRemoteHost></NewRemoteHost>
-    </u:AddAnyPortMapping>
-</s:Body>
-</s:Envelope>",
+        </u:AddAnyPortMapping>"#,
         protocol,
         external_port,
         local_addr.ip(),
         local_addr.port(),
         lease_duration,
         description,
-    )
+    ))
 }
 
 pub fn format_add_port_mapping_message(
@@ -72,10 +79,8 @@ pub fn format_add_port_mapping_message(
     lease_duration: u32,
     description: &str,
 ) -> String {
-    format!("<?xml version=\"1.0\"?>
-<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">
-<s:Body>
-    <u:AddPortMapping xmlns:u=\"urn:schemas-upnp-org:service:WANIPConnection:1\">
+    format_message(format!(
+        r#"<u:AddPortMapping xmlns:u="urn:schemas-upnp-org:service:WANIPConnection:1">
         <NewProtocol>{}</NewProtocol>
         <NewExternalPort>{}</NewExternalPort>
         <NewInternalClient>{}</NewInternalClient>
@@ -84,41 +89,33 @@ pub fn format_add_port_mapping_message(
         <NewPortMappingDescription>{}</NewPortMappingDescription>
         <NewEnabled>1</NewEnabled>
         <NewRemoteHost></NewRemoteHost>
-    </u:AddPortMapping>
-</s:Body>
-</s:Envelope>",
+        </u:AddPortMapping>"#,
         protocol,
         external_port,
         local_addr.ip(),
         local_addr.port(),
         lease_duration,
         description,
-    )
+    ))
 }
 
 pub fn format_delete_port_message(protocol: PortMappingProtocol, external_port: u16) -> String {
-    format!("<?xml version=\"1.0\"?>
-<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">
-<s:Body>
-    <u:DeletePortMapping xmlns:u=\"urn:schemas-upnp-org:service:WANIPConnection:1\">
+    format_message(format!(
+        r#"<u:DeletePortMapping xmlns:u="urn:schemas-upnp-org:service:WANIPConnection:1">
         <NewProtocol>{}</NewProtocol>
         <NewExternalPort>{}</NewExternalPort>
         <NewRemoteHost></NewRemoteHost>
-    </u:DeletePortMapping>
-</s:Body>
-</s:Envelope>",
+        </u:DeletePortMapping>"#,
         protocol,
         external_port
-    )
+    ))
 }
 
 pub fn formate_get_generic_port_mapping_entry_message(port_mapping_index: u32) -> String {
-    format!("<?xml version=\"1.0\"?>
-    <s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">
-        <s:Body>
-            <u:GetGenericPortMappingEntry xmlns:u=\"urn:schemas-upnp-org:service:WANIPConnection:1\">
-                <NewPortMappingIndex>{}</NewPortMappingIndex>
-            </u:GetGenericPortMappingEntry>
-        </s:Body>
-    </s:Envelope>", port_mapping_index)
+    format_message(format!(
+        r#"<u:GetGenericPortMappingEntry xmlns:u="urn:schemas-upnp-org:service:WANIPConnection:1">
+        <NewPortMappingIndex>{}</NewPortMappingIndex>
+        </u:GetGenericPortMappingEntry>"#,
+        port_mapping_index
+    ))
 }

--- a/src/common/messages.rs
+++ b/src/common/messages.rs
@@ -55,7 +55,7 @@ pub fn format_add_any_port_mapping_message(
 ) -> String {
     let args = schema
         .iter()
-        .map(|argument| {
+        .filter_map(|argument| {
             let value = match argument.as_str() {
                 "NewEnabled" => 1.to_string(),
                 "NewExternalPort" => external_port.to_string(),
@@ -65,9 +65,16 @@ pub fn format_add_any_port_mapping_message(
                 "NewPortMappingDescription" => description.to_string(),
                 "NewProtocol" => protocol.to_string(),
                 "NewRemoteHost" => "".to_string(),
-                _ => panic!("Nope"),
+                unknown => {
+                    warn!("Unknown argument: {}", unknown);
+                    return None;
+                }
             };
-            format!("<{argument}>{value}</{argument}>", argument = argument, value = value)
+            Some(format!(
+                "<{argument}>{value}</{argument}>",
+                argument = argument,
+                value = value
+            ))
         })
         .collect::<Vec<_>>()
         .join("\n");
@@ -90,7 +97,7 @@ pub fn format_add_port_mapping_message(
 ) -> String {
     let args = schema
         .iter()
-        .map(|argument| {
+        .filter_map(|argument| {
             let value = match argument.as_str() {
                 "NewEnabled" => 1.to_string(),
                 "NewExternalPort" => external_port.to_string(),
@@ -100,9 +107,16 @@ pub fn format_add_port_mapping_message(
                 "NewPortMappingDescription" => description.to_string(),
                 "NewProtocol" => protocol.to_string(),
                 "NewRemoteHost" => "".to_string(),
-                _ => panic!("Nope"),
+                unknown => {
+                    warn!("Unknown argument: {}", unknown);
+                    return None;
+                }
             };
-            format!("<{argument}>{value}</{argument}>", argument = argument, value = value)
+            Some(format!(
+                "<{argument}>{value}</{argument}>",
+                argument = argument,
+                value = value
+            ))
         })
         .collect::<Vec<_>>()
         .join("\n");
@@ -118,14 +132,21 @@ pub fn format_add_port_mapping_message(
 pub fn format_delete_port_message(schema: &Vec<String>, protocol: PortMappingProtocol, external_port: u16) -> String {
     let args = schema
         .iter()
-        .map(|argument| {
+        .filter_map(|argument| {
             let value = match argument.as_str() {
                 "NewExternalPort" => external_port.to_string(),
                 "NewProtocol" => protocol.to_string(),
                 "NewRemoteHost" => "".to_string(),
-                _ => panic!("Nope"),
+                unknown => {
+                    warn!("Unknown argument: {}", unknown);
+                    return None;
+                }
             };
-            format!("<{argument}>{value}</{argument}>", argument = argument, value = value)
+            Some(format!(
+                "<{argument}>{value}</{argument}>",
+                argument = argument,
+                value = value
+            ))
         })
         .collect::<Vec<_>>()
         .join("\n");

--- a/src/common/messages.rs
+++ b/src/common/messages.rs
@@ -46,68 +46,95 @@ pub fn format_get_external_ip_message() -> String {
 }
 
 pub fn format_add_any_port_mapping_message(
+    schema: &Vec<String>,
     protocol: PortMappingProtocol,
     external_port: u16,
     local_addr: SocketAddrV4,
     lease_duration: u32,
     description: &str,
 ) -> String {
+    let args = schema
+        .iter()
+        .map(|argument| {
+            let value = match argument.as_str() {
+                "NewEnabled" => 1.to_string(),
+                "NewExternalPort" => external_port.to_string(),
+                "NewInternalClient" => local_addr.ip().to_string(),
+                "NewInternalPort" => local_addr.port().to_string(),
+                "NewLeaseDuration" => lease_duration.to_string(),
+                "NewPortMappingDescription" => description.to_string(),
+                "NewProtocol" => protocol.to_string(),
+                "NewRemoteHost" => "".to_string(),
+                _ => panic!("Nope"),
+            };
+            format!("<{argument}>{value}</{argument}>", argument = argument, value = value)
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
     format_message(format!(
         r#"<u:AddAnyPortMapping xmlns:u="urn:schemas-upnp-org:service:WANIPConnection:1">
-        <NewProtocol>{}</NewProtocol>
-        <NewExternalPort>{}</NewExternalPort>
-        <NewInternalClient>{}</NewInternalClient>
-        <NewInternalPort>{}</NewInternalPort>
-        <NewLeaseDuration>{}</NewLeaseDuration>
-        <NewPortMappingDescription>{}</NewPortMappingDescription>
-        <NewEnabled>1</NewEnabled>
-        <NewRemoteHost></NewRemoteHost>
+        {}
         </u:AddAnyPortMapping>"#,
-        protocol,
-        external_port,
-        local_addr.ip(),
-        local_addr.port(),
-        lease_duration,
-        description,
+        args,
     ))
 }
 
 pub fn format_add_port_mapping_message(
+    schema: &Vec<String>,
     protocol: PortMappingProtocol,
     external_port: u16,
     local_addr: SocketAddrV4,
     lease_duration: u32,
     description: &str,
 ) -> String {
+    let args = schema
+        .iter()
+        .map(|argument| {
+            let value = match argument.as_str() {
+                "NewEnabled" => 1.to_string(),
+                "NewExternalPort" => external_port.to_string(),
+                "NewInternalClient" => local_addr.ip().to_string(),
+                "NewInternalPort" => local_addr.port().to_string(),
+                "NewLeaseDuration" => lease_duration.to_string(),
+                "NewPortMappingDescription" => description.to_string(),
+                "NewProtocol" => protocol.to_string(),
+                "NewRemoteHost" => "".to_string(),
+                _ => panic!("Nope"),
+            };
+            format!("<{argument}>{value}</{argument}>", argument = argument, value = value)
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
     format_message(format!(
         r#"<u:AddPortMapping xmlns:u="urn:schemas-upnp-org:service:WANIPConnection:1">
-        <NewProtocol>{}</NewProtocol>
-        <NewExternalPort>{}</NewExternalPort>
-        <NewInternalClient>{}</NewInternalClient>
-        <NewInternalPort>{}</NewInternalPort>
-        <NewLeaseDuration>{}</NewLeaseDuration>
-        <NewPortMappingDescription>{}</NewPortMappingDescription>
-        <NewEnabled>1</NewEnabled>
-        <NewRemoteHost></NewRemoteHost>
+        {}
         </u:AddPortMapping>"#,
-        protocol,
-        external_port,
-        local_addr.ip(),
-        local_addr.port(),
-        lease_duration,
-        description,
+        args,
     ))
 }
 
-pub fn format_delete_port_message(protocol: PortMappingProtocol, external_port: u16) -> String {
+pub fn format_delete_port_message(schema: &Vec<String>, protocol: PortMappingProtocol, external_port: u16) -> String {
+    let args = schema
+        .iter()
+        .map(|argument| {
+            let value = match argument.as_str() {
+                "NewExternalPort" => external_port.to_string(),
+                "NewProtocol" => protocol.to_string(),
+                "NewRemoteHost" => "".to_string(),
+                _ => panic!("Nope"),
+            };
+            format!("<{argument}>{value}</{argument}>", argument = argument, value = value)
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
     format_message(format!(
         r#"<u:DeletePortMapping xmlns:u="urn:schemas-upnp-org:service:WANIPConnection:1">
-        <NewProtocol>{}</NewProtocol>
-        <NewExternalPort>{}</NewExternalPort>
-        <NewRemoteHost></NewRemoteHost>
+        {}
         </u:DeletePortMapping>"#,
-        protocol,
-        external_port
+        args,
     ))
 }
 

--- a/src/common/parsing.rs
+++ b/src/common/parsing.rs
@@ -241,7 +241,7 @@ pub fn parse_get_external_ip_response(result: RequestResult) -> Result<Ipv4Addr,
     }
 }
 
-pub fn parse_add_any_port_mapping_response(result: RequestResult) -> Result<u16, Option<AddAnyPortError>> {
+pub fn parse_add_any_port_mapping_response(result: RequestResult) -> Result<u16, AddAnyPortError> {
     match result {
         Ok(resp) => {
             match resp
@@ -251,17 +251,14 @@ pub fn parse_add_any_port_mapping_response(result: RequestResult) -> Result<u16,
                 .and_then(|t| t.parse::<u16>().ok())
             {
                 Some(port) => Ok(port),
-                None => Err(Some(AddAnyPortError::RequestError(RequestError::InvalidResponse(
-                    resp.text,
-                )))),
+                None => Err(AddAnyPortError::RequestError(RequestError::InvalidResponse(resp.text))),
             }
         }
         Err(err) => Err(match err {
-            RequestError::ErrorCode(401, _) => None,
-            RequestError::ErrorCode(605, _) => Some(AddAnyPortError::DescriptionTooLong),
-            RequestError::ErrorCode(606, _) => Some(AddAnyPortError::ActionNotAuthorized),
-            RequestError::ErrorCode(728, _) => Some(AddAnyPortError::NoPortsAvailable),
-            e => Some(AddAnyPortError::RequestError(e)),
+            RequestError::ErrorCode(605, _) => AddAnyPortError::DescriptionTooLong,
+            RequestError::ErrorCode(606, _) => AddAnyPortError::ActionNotAuthorized,
+            RequestError::ErrorCode(728, _) => AddAnyPortError::NoPortsAvailable,
+            e => AddAnyPortError::RequestError(e),
         }),
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,6 +21,8 @@ pub enum RequestError {
     InvalidResponse(String),
     /// The gateway returned an unhandled error code and description.
     ErrorCode(u16, String),
+    /// Action is not supported by the gateway
+    UnsupportedAction(String),
     /// When using the aio feature.
     #[cfg(feature = "aio")]
     HyperError(hyper::Error),
@@ -81,6 +83,7 @@ impl fmt::Display for RequestError {
             RequestError::InvalidResponse(ref e) => write!(f, "Invalid response from gateway: {}", e),
             RequestError::IoError(ref e) => write!(f, "IO error. {}", e),
             RequestError::ErrorCode(n, ref e) => write!(f, "Gateway response error {}: {}", n, e),
+            RequestError::UnsupportedAction(ref e) => write!(f, "Gateway does not support action: {}", e),
             #[cfg(feature = "aio")]
             RequestError::HyperError(ref e) => write!(f, "Hyper Error: {}", e),
             #[cfg(feature = "aio")]
@@ -98,6 +101,7 @@ impl std::error::Error for RequestError {
             RequestError::InvalidResponse(..) => None,
             RequestError::IoError(ref e) => Some(e),
             RequestError::ErrorCode(..) => None,
+            RequestError::UnsupportedAction(..) => None,
             #[cfg(feature = "aio")]
             RequestError::HyperError(ref e) => Some(e),
             #[cfg(feature = "aio")]

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -8,7 +8,7 @@ use crate::errors::{self, AddAnyPortError, AddPortError, GetExternalIpError, Rem
 use crate::PortMappingProtocol;
 
 /// This structure represents a gateway found by the search functions.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug)]
 pub struct Gateway {
     /// Socket address of the gateway
     pub addr: SocketAddrV4,

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -12,6 +12,8 @@ use crate::PortMappingProtocol;
 pub struct Gateway {
     /// Socket address of the gateway
     pub addr: SocketAddrV4,
+    /// Root url of the device
+    pub root_url: String,
     /// Control url of the device
     pub control_url: String,
 }

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt;
 use std::net::{Ipv4Addr, SocketAddrV4};
 
@@ -18,6 +19,8 @@ pub struct Gateway {
     pub control_url: String,
     /// Url to get schema data from
     pub control_schema_url: String,
+    /// Control schema for all actions
+    pub control_schema: HashMap<String, Vec<String>>,
 }
 
 impl Gateway {

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -173,7 +173,9 @@ impl Gateway {
         self.perform_request(
             messages::ADD_PORT_MAPPING_HEADER,
             &messages::format_add_port_mapping_message(
-                self.control_schema.get("AddPortMapping").unwrap(),
+                self.control_schema
+                    .get("AddPortMapping")
+                    .ok_or(RequestError::UnsupportedAction("AddPortMapping".to_string()))?,
                 protocol,
                 external_port,
                 local_addr,
@@ -211,15 +213,21 @@ impl Gateway {
 
     /// Remove a port mapping.
     pub fn remove_port(&self, protocol: PortMappingProtocol, external_port: u16) -> Result<(), RemovePortError> {
-        parsing::parse_delete_port_mapping_response(self.perform_request(
-            messages::DELETE_PORT_MAPPING_HEADER,
-            &messages::format_delete_port_message(
-                self.control_schema.get("DeletePortMapping").unwrap(),
-                protocol,
-                external_port,
+        parsing::parse_delete_port_mapping_response(
+            self.perform_request(
+                messages::DELETE_PORT_MAPPING_HEADER,
+                &messages::format_delete_port_message(
+                    self.control_schema
+                        .get("DeletePortMapping")
+                        .ok_or(RemovePortError::RequestError(RequestError::UnsupportedAction(
+                            "DeletePortMapping".to_string(),
+                        )))?,
+                    protocol,
+                    external_port,
+                ),
+                "DeletePortMappingResponse",
             ),
-            "DeletePortMappingResponse",
-        ))
+        )
     }
 
     /// Get one port mapping entry

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -16,6 +16,8 @@ pub struct Gateway {
     pub root_url: String,
     /// Control url of the device
     pub control_url: String,
+    /// Url to get schema data from
+    pub control_schema_url: String,
 }
 
 impl Gateway {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 //! You can then communicate with the device via this object.
 
 extern crate attohttpc;
-#[cfg(feature = "aio")]
 #[macro_use]
 extern crate log;
 #[cfg(feature = "aio")]

--- a/src/search.rs
+++ b/src/search.rs
@@ -41,7 +41,7 @@ pub fn search_gateway(options: SearchOptions) -> Result<Gateway, SearchError> {
 
         return Ok(Gateway {
             addr,
-            control_url: control_url,
+            control_url,
         });
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -41,6 +41,7 @@ pub fn search_gateway(options: SearchOptions) -> Result<Gateway, SearchError> {
 
         return Ok(Gateway {
             addr,
+            root_url,
             control_url,
         });
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -33,12 +33,16 @@ pub fn search_gateway(options: SearchOptions) -> Result<Gateway, SearchError> {
         let text = str::from_utf8(&buf[..read])?;
 
         let location = parsing::parse_search_result(text)?;
-        if let Ok(control_url) = get_control_url(&location) {
-            return Ok(Gateway {
-                addr: location.0,
-                control_url: control_url,
-            });
-        }
+
+        let control_url = match get_control_url(&location) {
+            Ok(o) => o,
+            Err(..) => continue,
+        };
+
+        return Ok(Gateway {
+            addr: location.0,
+            control_url: control_url,
+        });
     }
 }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -34,7 +34,7 @@ pub fn search_gateway(options: SearchOptions) -> Result<Gateway, SearchError> {
 
         let (addr, root_url) = parsing::parse_search_result(text)?;
 
-        let control_url = match get_control_url(&addr, &root_url) {
+        let (control_schema_url, control_url) = match get_control_urls(&addr, &root_url) {
             Ok(o) => o,
             Err(..) => continue,
         };
@@ -43,12 +43,13 @@ pub fn search_gateway(options: SearchOptions) -> Result<Gateway, SearchError> {
             addr,
             root_url,
             control_url,
+            control_schema_url,
         });
     }
 }
 
-fn get_control_url(addr: &SocketAddrV4, root_url: &String) -> Result<String, SearchError> {
+fn get_control_urls(addr: &SocketAddrV4, root_url: &String) -> Result<(String, String), SearchError> {
     let url = format!("http://{}:{}{}", addr.ip(), addr.port(), root_url);
     let response = attohttpc::get(&url).send()?;
-    parsing::parse_control_url(&response.bytes()?[..])
+    parsing::parse_control_urls(&response.bytes()?[..])
 }


### PR DESCRIPTION
According to the specification for [UPnP Devices][1], the arguments for the control actions need to match the order of arguments as desribed in the schema. To achieve that, we retrieve the schemas when searching for a compitable gateway and use the appropriate schema for each action to build the arguments properly.

Fixes #48.
    
[1]: https://openconnectivity.org/upnp-specs/UPnP-arch-DeviceArchitecture-v2.0-20200417.pdf