### PR TITLE
Allow WANIPConnection:2 in parse_service()

### DIFF
--- a/src/common/parsing.rs
+++ b/src/common/parsing.rs
@@ -95,6 +95,7 @@ fn parse_service(service: &Element) -> Option<(String, String)> {
     if [
         "urn:schemas-upnp-org:service:WANPPPConnection:1",
         "urn:schemas-upnp-org:service:WANIPConnection:1",
+        "urn:schemas-upnp-org:service:WANIPConnection:2",
     ]
     .contains(&service_type.as_str())
     {


### PR DESCRIPTION
Some routers only advertise WANIPConnection v2 and not v1. In this case parse_service() simply returns None which eventually causes search_gateway() to fail.

http://upnp.org/specs/gw/UPnP-gw-WANIPConnection-v2-Service.pdf
Section 1.2 specifies that WANIPConnection v2 is compatible with v1.

Allowing WANIPConnection:2 makes the library work correctly with wider range of routers (in particular, AmpliFi HD now works correctly).

This addresses one of the issues described in #12 